### PR TITLE
Support Python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: v2.7.0
     hooks:
     -   id: setup-cfg-fmt
+        args: [--min-py-version, '3.8']
 -   repo: https://github.com/asottile/reorder-python-imports
     rev: v3.14.0
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.8
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Currently, this package declares that it needs Python >= 3.9, and so pip will not allow you to install it on earlier Python versions.

However, this package actually works fine on Python 3.8; I force-installed it using `pip install 'shfmt-py~=3.11' --ignore-requires-python` and it installed and worked with no issues.

The only reason that this package is currently set to require Python >= 3.9 is because that's the default `min-py-version` for the setup_cfg_fmt autoformatter, and so the formatter automatically changed the value in this repo's setup.cd (see commit e710e8991e4a3a4b7d7656fc904409a0eeeaeabc). This PR updates the pre-commit config to pass `--min-py-version '3.8'` to setup_cfg_fmt 