### PR TITLE
Fix pre-commit on Python 3.12+ while keeping 3.9 floor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,20 +10,21 @@ repos:
     -   id: name-tests-test
     -   id: requirements-txt-fixer
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.8.0
+    rev: v3.2.0
     hooks:
     -   id: setup-cfg-fmt
+        args: [--min-py-version, '3.9']
 -   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.15.0
+    rev: v3.16.0
     hooks:
     -   id: reorder-python-imports
         args: [--py39-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.2.0
+    rev: v4.0.0
     hooks:
     -   id: add-trailing-comma
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py39-plus]


### PR DESCRIPTION
## Why

`pre-commit.ci` has been red on every PR (incl. master) because `pyupgrade v3.20.0` crashes on Python 3.12+:

```
TypeError: cannot use a bytes pattern on a string-like object
  pyupgrade/_main.py:297  →  tokenize.cookie_re.match(token.src)
```

`tokenize.cookie_re` became a bytes pattern in newer CPython; `pyupgrade ≥3.21` handles it.

## What

- Bump `pyupgrade` → v3.21.2 (fixes the crash)
- Bump peer hooks: `pre-commit-hooks` v6, `setup-cfg-fmt` v3.2, `reorder-python-imports` v3.16, `add-trailing-comma` v4
- Pin `setup-cfg-fmt` to `--min-py-version=3.9` so it stops auto-bumping `python_requires` off the supported floor

## Notes

Supersedes #35 — that PR's autofix had silently bumped `python_requires` to `>=3.10`, which is why its CI matrix went red on py39. This PR keeps the 3.9 floor intact.

`--py39-plus` flags on `pyupgrade` / `reorder-python-imports` stay, so rewritten output remains 3.9-syntactically-safe. Note that the *hooks themselves* now need Python 3.10+ to run locally — contributors will need a modern Python, but end users keep 3.9 support.