### PR TITLE
Add least-privilege permissions to test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Add a job-level `permissions: contents: read` block to the `test` job in `main.yml`. The job needs to clone the repo and run shfmt smoke tests — nothing else — so pinning `GITHUB_TOKEN` to read-only on `contents` is the right scope.

## Why

Without an explicit `permissions:` block, the workflow inherits whatever the repo's default `GITHUB_TOKEN` scopes are, which can be broader than needed. Locking it down is a security baseline and matches the pattern in `update_shfmt_checksums.yml` (which has its own explicit block).

## Notes

Originally a CodeRabbit suggestion on #43, missed before that PR was merged. This is the catch-up PR. +2 lines.