### PR TITLE
Update dependency mvdan/sh to v3.13.0 (manual test + fix update flow)

### DIFF
--- a/.github/workflows/update_readme.py
+++ b/.github/workflows/update_readme.py
@@ -6,32 +6,33 @@ import re
 
 
 def extract_version_from_setup():
-    print('[DEBUG] Opening setup.py to read the version...')  # Debug log for reading setup.py
-    # Open and read the setup.py file
+    print('[DEBUG] Opening setup.py to read the version...')
     with open('setup.py') as setup_file:
         setup_content = setup_file.read()
 
-    # Find the version variable in setup.py
-    version_match = re.search(r"SHFMT_VERSION\s*=\s*'(\d+\.\d+\.\d+)'", setup_content)
+    shfmt_match = re.search(r"SHFMT_VERSION\s*=\s*'(\d+\.\d+\.\d+)'", setup_content)
+    if not shfmt_match:
+        raise ValueError('SHFMT_VERSION not found in setup.py')
 
-    if version_match:
-        version = version_match.group(1)
-        print(f"[DEBUG] Found version in setup.py: {version}")  # Log the found version
-        return version
-    else:
-        raise ValueError('Version not found in setup.py')
+    py_match = re.search(r"PY_VERSION\s*=\s*'(\d+)'", setup_content)
+    if not py_match:
+        raise ValueError('PY_VERSION not found in setup.py')
+
+    shfmt_version = shfmt_match.group(1)
+    py_version = py_match.group(1)
+    print(f"[DEBUG] Found in setup.py: SHFMT_VERSION={shfmt_version}, PY_VERSION={py_version}")
+    return shfmt_version, py_version
 
 # Function to update the version in README.md
 
 
 def update_readme_version():
     try:
-        # Extract the version from setup.py
-        SHFMT_VERSION = extract_version_from_setup()
+        shfmt_version, py_version = extract_version_from_setup()
 
-        # Append '.0' to the version (if not already appended)
-        adjusted_version = f"{SHFMT_VERSION}.1"
-        print(f"[DEBUG] Adjusted version: {adjusted_version}")  # Debug log for adjusted version
+        # README uses the full pip package version: SHFMT_VERSION.PY_VERSION
+        adjusted_version = f"{shfmt_version}.{py_version}"
+        print(f"[DEBUG] Adjusted version: {adjusted_version}")
 
         # Open and read the README.md file
         print('[DEBUG] Opening README.md to read its content...')  # Debug log for reading README.md

--- a/.github/workflows/update_shfmt_checksums.py
+++ b/.github/workflows/update_shfmt_checksums.py
@@ -49,7 +49,7 @@ headers = {}
 token = os.environ.get('GITHUB_TOKEN')
 if token:
     headers['Authorization'] = f'Bearer {token}'
-response = requests.get(api_url, headers=headers)
+response = requests.get(api_url, headers=headers, timeout=30)
 if response.status_code != 200:
     print(f"[ERROR] Failed to fetch release metadata (HTTP {response.status_code})")
     sys.exit(1)
@@ -77,6 +77,14 @@ for asset in assets:
 
 if not checksums:
     print('[ERROR] No checksums extracted! The release format may have changed again.')
+    sys.exit(1)
+
+# Partial extraction would silently leave stale hashes in setup.py for any
+# missing platform — fail loud instead.
+expected = set(ARCH_MAP.values())
+missing = expected - set(checksums)
+if missing:
+    print(f"[ERROR] Missing checksums for expected platforms: {sorted(missing)}")
     sys.exit(1)
 
 

--- a/.github/workflows/update_shfmt_checksums.py
+++ b/.github/workflows/update_shfmt_checksums.py
@@ -90,12 +90,12 @@ for asset in assets:
         continue
 
     digest = asset.get('digest', '')
-    if not digest.startswith('sha256:'):
-        print(f"[WARNING] Asset {name} has no sha256 digest (got: {digest!r})")
+    if not re.fullmatch(r'sha256:[a-fA-F0-9]{64}', digest):
+        print(f"[WARNING] Asset {name} has no valid sha256 digest (got: {digest!r})")
         continue
 
     var_name = ARCH_MAP[expected_key].format(version=shfmt_version)
-    checksums[var_name] = digest.removeprefix('sha256:')
+    checksums[var_name] = digest.split(':', 1)[1].lower()
     print(f"[INFO] Found checksum: {var_name} -> {checksums[var_name]}")
 
 if not checksums:

--- a/.github/workflows/update_shfmt_checksums.py
+++ b/.github/workflows/update_shfmt_checksums.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
 
 import requests
@@ -38,6 +39,28 @@ if not match:
 
 shfmt_version = match.group(1)
 print(f"[INFO] Found SHFMT_VERSION: {shfmt_version}")
+
+# Detect whether SHFMT_VERSION just changed (compared to HEAD~1). If so,
+# we reset PY_VERSION later so the new release starts at .1 rather than
+# carrying forward the previous wrapper's iteration counter.
+try:
+    prev_setup = subprocess.check_output(
+        ['git', 'show', 'HEAD~1:setup.py'], text=True,
+    )
+    prev_match = re.search(r"SHFMT_VERSION = '([^']+)'", prev_setup)
+    prev_shfmt_version = prev_match.group(1) if prev_match else None
+except subprocess.CalledProcessError:
+    prev_shfmt_version = None
+
+reset_py_version = (
+    prev_shfmt_version is not None
+    and prev_shfmt_version != shfmt_version
+)
+if reset_py_version:
+    print(
+        f"[INFO] SHFMT_VERSION changed ({prev_shfmt_version} -> {shfmt_version});"
+        f" will reset PY_VERSION to '1'.",
+    )
 
 api_url = GITHUB_API_URL.format(version=shfmt_version)
 print(f"[INFO] Fetching release metadata from: {api_url}")
@@ -109,6 +132,15 @@ for var_name, sha in checksums.items():
         updated = True
     else:
         print(f"[WARNING] Could not find pattern for {var_name}. Check your setup.py format.")
+
+if reset_py_version:
+    py_pattern = r"(PY_VERSION\s*=\s*)'[^']+'"
+    if re.search(py_pattern, new_content):
+        new_content = re.sub(py_pattern, r"\1'1'", new_content)
+        print('[INFO] Reset PY_VERSION to 1')
+        updated = True
+    else:
+        print('[WARNING] PY_VERSION not found in setup.py — leaving alone')
 
 if not updated:
     print('[WARNING] No checksums were updated. Maybe they are already correct?')

--- a/.github/workflows/update_shfmt_checksums.py
+++ b/.github/workflows/update_shfmt_checksums.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import sys
 
@@ -7,7 +8,9 @@ import requests
 
 # File paths and URLs
 SHFMT_VERSION_FILE = 'setup.py'
-GITHUB_RELEASES_URL = 'https://github.com/mvdan/sh/releases/download/v{version}/sha256sums.txt'
+# mvdan/sh stopped shipping sha256sums.txt in v3.13.0+; GitHub now exposes
+# per-asset sha256 digests natively via the releases API.
+GITHUB_API_URL = 'https://api.github.com/repos/mvdan/sh/releases/tags/v{version}'
 
 ARCH_MAP = {
     'shfmt_v{version}_linux_arm': 'linux_arm',
@@ -36,37 +39,44 @@ if not match:
 shfmt_version = match.group(1)
 print(f"[INFO] Found SHFMT_VERSION: {shfmt_version}")
 
-checksum_url = GITHUB_RELEASES_URL.format(version=shfmt_version)
-print(f"[INFO] Downloading checksum file from: {checksum_url}")
+api_url = GITHUB_API_URL.format(version=shfmt_version)
+print(f"[INFO] Fetching release metadata from: {api_url}")
 
-# Step 2: Download `sha256sums.txt`
-response = requests.get(checksum_url)
+# Step 2: Fetch release metadata from GitHub
+# Use GITHUB_TOKEN if available to avoid the 60 req/hr unauthenticated limit;
+# GitHub Actions populates this automatically when the step has the env wired.
+headers = {}
+token = os.environ.get('GITHUB_TOKEN')
+if token:
+    headers['Authorization'] = f'Bearer {token}'
+response = requests.get(api_url, headers=headers)
 if response.status_code != 200:
-    print(f"[ERROR] Failed to download {checksum_url} (HTTP {response.status_code})")
+    print(f"[ERROR] Failed to fetch release metadata (HTTP {response.status_code})")
     sys.exit(1)
 
-checksums = {}
-lines = response.text.splitlines()
-print(f"[INFO] Downloaded checksum file ({len(lines)} lines). Processing...")
+assets = response.json().get('assets', [])
+print(f"[INFO] Got {len(assets)} release assets. Processing...")
 
-for line in lines:
-    parts = line.split()
-    if len(parts) != 2:
-        print(f"[WARNING] Skipping malformed line: {line}")
+checksums = {}
+for asset in assets:
+    name = asset['name']
+    expected_key = name.replace(shfmt_version, '{version}')
+
+    if expected_key not in ARCH_MAP:
+        print(f"[DEBUG] Skipping unrecognized asset: {name}")
         continue
 
-    sha, filename = parts
-    expected_key = filename.replace(shfmt_version, '{version}')
+    digest = asset.get('digest', '')
+    if not digest.startswith('sha256:'):
+        print(f"[WARNING] Asset {name} has no sha256 digest (got: {digest!r})")
+        continue
 
-    if expected_key in ARCH_MAP:
-        var_name = ARCH_MAP[expected_key].format(version=shfmt_version)
-        checksums[var_name] = sha
-        print(f"[INFO] Found checksum: {var_name} -> {sha}")
-    else:
-        print(f"[DEBUG] Skipping unrecognized file: {filename}")
+    var_name = ARCH_MAP[expected_key].format(version=shfmt_version)
+    checksums[var_name] = digest.removeprefix('sha256:')
+    print(f"[INFO] Found checksum: {var_name} -> {checksums[var_name]}")
 
 if not checksums:
-    print('[ERROR] No matching checksums found! Check the `sha256sums.txt` format.')
+    print('[ERROR] No checksums extracted! The release format may have changed again.')
     sys.exit(1)
 
 

--- a/.github/workflows/update_shfmt_checksums.yml
+++ b/.github/workflows/update_shfmt_checksums.yml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Get last commit message
         id: get_commit_message
-        run: echo "commit_message=$(git log -1 --pretty=%B)" >> $GITHUB_ENV
+        # %s = subject line only; %B (full body) breaks $GITHUB_ENV on multi-line messages.
+        run: echo "commit_message=$(git log -1 --pretty=%s)" >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/update_shfmt_checksums.yml
+++ b/.github/workflows/update_shfmt_checksums.yml
@@ -33,6 +33,8 @@ jobs:
         run: pip install requests
 
       - name: Run checksum update script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/workflows/update_shfmt_checksums.py
 
       - name: Run README update script

--- a/.github/workflows/update_shfmt_checksums.yml
+++ b/.github/workflows/update_shfmt_checksums.yml
@@ -1,12 +1,14 @@
 name: Update shfmt checksums
 
 on:
-  push:
-    branches:
-      - renovate/mvdan-sh**  # Only run when Renovate updates SHFMT_VERSION
+  pull_request:
+    branches: [master]
+    paths: [setup.py]
 
 jobs:
   update-checksums:
+    # Only on Renovate's mvdan/sh bumps; skips manual or fork PRs.
+    if: startsWith(github.head_ref, 'renovate/mvdan-sh')
     runs-on: ubuntu-latest
 
     permissions:
@@ -19,6 +21,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT }}
+          # Need history so the script can read setup.py at HEAD~1 to
+          # detect SHFMT_VERSION changes and reset PY_VERSION on bumps.
+          ref: ${{ github.head_ref }}
+          fetch-depth: 2
 
       - name: Get last commit message
         id: get_commit_message

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Sample `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/maxwinterstein/shfmt-py
-  rev: v3.13.0.2
+  rev: v3.13.0.1
   hooks:
     - id: shfmt
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Sample `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/maxwinterstein/shfmt-py
-  rev: v3.12.0.1
+  rev: v3.13.0.2
   hooks:
     - id: shfmt
 ```

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ POSTFIX_SHA256 = {
 }
 POSTFIX_SHA256[('cygwin', 'x86_64')] = POSTFIX_SHA256[('win32', 'AMD64')]
 POSTFIX_SHA256[('linux', 'armv7l')] = POSTFIX_SHA256[('linux', 'armv6hf')]
-PY_VERSION = '2'
+PY_VERSION = '1'
 
 
 def get_download_url() -> tuple[str, str]:

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,13 @@ from distutils.core import Command
 from setuptools import setup
 from setuptools.command.install import install as orig_install
 
-linux_arm = 'a93c1ed5be25ce9dd0fd62c4cf0af7453740d234725877b973e6c6a8c7598500'
-linux_arm64 = '5f3fe3fa6a9f766e6a182ba79a94bef8afedafc57db0b1ad32b0f67fae971ba4'
-linux_amd64 = 'd9fbb2a9c33d13f47e7618cf362a914d029d02a6df124064fff04fd688a745ea'
-darwin_amd64 = 'c31548693de6584e6164b7ed5fbb7b4a083f2d937ca94b4e0ddf59aa461a85e4'
-darwin_arm64 = 'd903802e0ce3ecbc82b98512f55ba370b0d37a93f3f78de394f5b657052b33dd'
-windows_amd64_exe = 'c8bda517ba1c640ce4a715c0fa665439ddbe4357ba5e9b77b0e51e70e2b9c94b'
-windows_386_exe = '92c1ef0af344a10f2cefe3ce4bc6793ae8b3719ac08fc01802bbd8eae105e534'
+linux_arm = '774b9a86cff4844179328cfbab2f602e75dcb68132e918e5271d015b3295c9c7'
+linux_arm64 = '2091a31afd47742051a77bf7cfd175533ab07e924c20ef3151cd108fa1cab5b0'
+linux_amd64 = '70aa99784703a8d6569bbf0b1e43e1a91906a4166bf1a79de42050a6d0de7551'
+darwin_amd64 = 'b6890a0009abf71d36d7c536ad56e3132c547ceb77cd5d5ee62b3469ab4e9417'
+darwin_arm64 = '650970603b5946dc6041836ddcfa7a19d99b5da885e4687f64575508e99cf718'
+windows_amd64_exe = '62241aaf6b0ca236f8625d8892784b73fa67ad40bc677a1ad1a64ae395f6a7d5'
+windows_386_exe = 'f3e32b2a320a3053837add32803d7fb3b730d3f10b84a867d327a549ef068fa0'
 
 SHFMT_VERSION = '3.13.0'
 POSTFIX_SHA256 = {

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ darwin_arm64 = 'd903802e0ce3ecbc82b98512f55ba370b0d37a93f3f78de394f5b657052b33dd
 windows_amd64_exe = 'c8bda517ba1c640ce4a715c0fa665439ddbe4357ba5e9b77b0e51e70e2b9c94b'
 windows_386_exe = '92c1ef0af344a10f2cefe3ce4bc6793ae8b3719ac08fc01802bbd8eae105e534'
 
-SHFMT_VERSION = '3.12.0'
+SHFMT_VERSION = '3.13.0'
 POSTFIX_SHA256 = {
     ('linux', 'armv6hf'): (
         'linux_arm',


### PR DESCRIPTION
## Why

Manual stand-in for what Renovate would have produced for mvdan/sh v3.13.0 (Renovate already has #40 for v3.13.1 — leaving that for the bot to handle on its own).

While testing, found the auto-update flow had been **silently broken since v3.13.0 was released (2026-03-09)** because mvdan/sh stopped shipping \`sha256sums.txt\` in that release. This PR also fixes the script so future renovate updates work again.

## What

1. \`setup.py\`: bump \`SHFMT_VERSION\` from 3.12.0 → 3.13.0 (the Renovate-equivalent change)
2. \`.github/workflows/update_shfmt_checksums.py\`: fetch release metadata via GitHub API and read each asset's native \`.digest\` field, instead of the now-missing \`sha256sums.txt\`. Optional \`GITHUB_TOKEN\` auth to avoid the 60 req/hr unauthenticated limit.
3. \`.github/workflows/update_shfmt_checksums.yml\`: pass \`GITHUB_TOKEN\` env to the script step.
4. \`.github/workflows/update_readme.py\`: read \`PY_VERSION\` from setup.py instead of hardcoding \`.1\` — kept README in sync with actual package version (currently \`PY_VERSION='2'\`).

## Expected behavior on this push

The 'Update shfmt checksums' workflow should trigger, regenerate the 7 sha256 hashes in setup.py, bump the README \`rev:\` to \`v3.13.0.2\`, and auto-commit "Apply automatic changes" back to this branch.

Closes the silent breakage discovered while triaging the queue.