### PR TITLE
Polish README + fix LICENSE detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,3 @@
-Copyright for portions of project shfmt-py are held by Ryan Rhee, 2019
-as part of the project located at https://github.com/shellcheck-py/shellcheck-py.
-All other copyright for this project are held by Max Winterstein, 2021.
-
 MIT License
 
 Copyright (c) 2019 Ryan Rhee
@@ -24,3 +20,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Copyright for portions of project shfmt-py are held by Ryan Rhee, 2019,
+as part of the project located at https://github.com/shellcheck-py/shellcheck-py.
+All other copyright for this project are held by Max Winterstein, 2021.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
+[![PyPI version](https://img.shields.io/pypi/v/shfmt-py.svg)](https://pypi.org/project/shfmt-py)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/shfmt-py.svg)](https://pypi.org/project/shfmt-py)
+[![Downloads](https://img.shields.io/pypi/dm/shfmt-py.svg)](https://pypi.org/project/shfmt-py)
+[![License](https://img.shields.io/github/license/MaxWinterstein/shfmt-py.svg)](https://github.com/MaxWinterstein/shfmt-py/blob/master/LICENSE)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/MaxWinterstein/shfmt-py/master.svg)](https://results.pre-commit.ci/latest/github/MaxWinterstein/shfmt-py/master)
 
 # shfmt-py
 
-A python wrapper to provide a pip-installable [shfmt] binary.
+Python-installable wrapper for [shfmt], the shell script formatter.
 
-Internally this package provides a convenient way to download the pre-built
-shellcheck binary for your particular platform.
+Internally this package downloads the pre-built `shfmt` binary for your platform at install time.
 
-This package is totally cloned from [shellcheck-py] and modified to provide `shfmt` instead.
+Modeled after [shellcheck-py], adapted for `shfmt`.
 
 ## Installation
 
@@ -19,12 +22,11 @@ pip install shfmt-py
 
 ### CLI
 
-After installation, the `shfmt` binary should be available in your
-environment (or `shfmt.exe` on windows).
+After installation, the `shfmt` binary is available on your `PATH` (or `shfmt.exe` on Windows).
 
 ### As pre-commit hook
 
-See [pre-commit] for instructions
+See [pre-commit] for instructions.
 
 Sample `.pre-commit-config.yaml`:
 


### PR DESCRIPTION
## Why

Two adjacent things to polish:

1. README had a copy-paste leftover from shellcheck-py and only one badge.
2. License badge on the new badge row showed *"not identifiable by GitHub"* — GitHub's license detector couldn't recognize the LICENSE because the file started with a 3-line prologue before the canonical MIT text.

## What

### README

- Add 4 new badges (PyPI version, supported Python versions, downloads, license) alongside the existing pre-commit.ci badge.
- Fix typo: `shellcheck` → `shfmt` in the "internally this package downloads…" line.
- Tighten the description and the CLI install-location sentence.
- Soften the origin note from *"totally cloned from shellcheck-py and modified to provide shfmt instead"* to *"Modeled after shellcheck-py, adapted for shfmt"*.

### LICENSE

- Reorder so the canonical MIT text comes first. GitHub's `licensee` parses from the top and stops when it doesn't see the expected header. With the prologue moved below a `---` separator, the repo will be detected as MIT (currently `Other / NOASSERTION`).
- Legal effect unchanged. Both copyright lines stay; the upstream-attribution prologue is preserved verbatim, just relocated.

Note: GitHub's license API reports against the default branch, so the License badge will keep saying "not identifiable" *until this PR is merged*. It will start showing **MIT** as soon as the change lands on master.