### PR TITLE
Fix Renovate + auto-update regexes after ruff double-quote conversion

### DIFF
--- a/.github/workflows/update_shfmt_checksums.py
+++ b/.github/workflows/update_shfmt_checksums.py
@@ -31,7 +31,7 @@ except FileNotFoundError:
     print("[ERROR] setup.py not found!")
     sys.exit(1)
 
-match = re.search(r"SHFMT_VERSION = '([^']+)'", content)
+match = re.search(r"""SHFMT_VERSION = ["']([^"']+)["']""", content)
 if not match:
     print("[ERROR] Could not find SHFMT_VERSION in setup.py!")
     sys.exit(1)
@@ -97,8 +97,9 @@ updated = False
 # Directly update variables in setup.py with the new checksums
 for var_name, sha in checksums.items():
     print(f"[DEBUG] var_name: {var_name}")
-    pattern = rf"({var_name}\s*=\s*)\'[a-fA-F0-9]{{64}}\'"
-    replacement = rf"\1'{sha}'"  # Corrected line
+    # Match either quote style (legacy single-quoted or current double-quoted).
+    pattern = rf"""({var_name}\s*=\s*)["'][a-fA-F0-9]{{64}}["']"""
+    replacement = rf'\1"{sha}"'  # Always emit double quotes (codebase convention).
 
     # Debug: print the pattern we are searching for
     print(f"[DEBUG] Searching for pattern: {pattern}")

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
         "/\\.py$/"
       ],
       "matchStrings": [
-        "SHFMT_VERSION = '(?<currentValue>[^']+)'"
+        "SHFMT_VERSION = [\"'](?<currentValue>[^\"']+)[\"']"
       ],
       "depNameTemplate": "mvdan/sh",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
## Why

PR #50 converted all string literals from single to double quotes via \`ruff format\`. Two regex sites still hardcoded single quotes and were missed in that PR (they're not Python source, so ruff didn't see them):

1. **\`renovate.json\` matchStrings** — \`SHFMT_VERSION = '(?<currentValue>[^']+)'\` doesn't match \`SHFMT_VERSION = "3.13.0"\`. Renovate has silently lost visibility of the shfmt version on master right now; no more upstream-bump PRs will get created.
2. **\`update_shfmt_checksums.py\`** — both the SHFMT_VERSION read regex and the per-platform hash pattern hardcoded single quotes. On the next Renovate bump the workflow would error with \`Could not find SHFMT_VERSION in setup.py\`.

Spotted by Max, as a follow-up to PR #50 already being merged.

## What

- \`renovate.json\`: accept either quote style on the input — \`[\"']\` character class.
- \`update_shfmt_checksums.py\`: same input-side relaxation. The replacement template now always emits **double quotes** so the next \`ruff format\` run is a no-op.

## Verified

Simulated a v3.13.0 → v3.13.1 bump locally; the script correctly fetched v3.13.1 hashes via the GitHub API and rewrote setup.py with double-quoted hash literals. \`ruff check\` and \`ruff format\` both happy with the result.