### PR TITLE
Wheel build on every PR + publish on release (closes #31)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,3 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
@@ -13,27 +5,83 @@ on:
     types: [published]
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-
+  build-wheels:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux_x86_64
+            host_platform: manylinux2014_x86_64
+          - os: ubuntu-24.04-arm
+            name: linux_aarch64
+            host_platform: manylinux2014_aarch64
+          - os: macos-latest
+            name: macos_arm64
+            host_platform: macosx-11.0-arm64
+          - os: macos-15-intel
+            name: macos_x86_64
+            host_platform: macosx-10.9-x86_64
+          - os: windows-latest
+            name: windows_amd64
+            host_platform: ''
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
-          # setuptools-scm derives the package version from the latest git
-          # tag, so we need the full history (not the default shallow clone).
+          # setuptools-scm derives the version from the latest git tag.
           fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: python -m build --sdist
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@e9ccbe5a211ba3e8363f472cae362b56b104e796
+      - run: pip install build
+      - name: Build wheel
+        env:
+          # Override the platform tag so the wheel is tagged for broad
+          # compatibility (e.g. manylinux2014 instead of bare linux_*).
+          # An empty value leaves the platform tag at setuptools' default.
+          _PYTHON_HOST_PLATFORM: ${{ matrix.host_platform }}
+        run: python -m build --wheel
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.name }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-sdist:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - run: pip install build
+      - run: python -m build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: List artifacts to publish
+        run: ls -la dist/
+      - uses: pypa/gh-action-pypi-publish@e9ccbe5a211ba3e8363f472cae362b56b104e796
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,8 +1,12 @@
-name: Upload Python Package
+name: Build (and publish on release) Python Package
 
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   build-wheels:
@@ -71,6 +75,9 @@ jobs:
 
   publish:
     needs: [build-wheels, build-sdist]
+    # Only actually publish on real release events; the build matrix above
+    # still runs on every PR / push to catch wheel-build regressions early.
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,14 +33,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # setuptools-scm derives the version from the latest git tag.
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.x"
-      - run: pip install build
+      - run: python -m pip install build
       - name: Build wheel
         env:
           # Override the platform tag so the wheel is tagged for broad
@@ -48,7 +48,7 @@ jobs:
           # An empty value leaves the platform tag at setuptools' default.
           _PYTHON_HOST_PLATFORM: ${{ matrix.host_platform }}
         run: python -m build --wheel
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: wheel-${{ matrix.name }}
           path: dist/*.whl
@@ -59,15 +59,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.x"
-      - run: pip install build
+      - run: python -m pip install build
       - run: python -m build --sdist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -82,7 +82,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## Why

[Issue #31](https://github.com/MaxWinterstein/shfmt-py/issues/31) requests offline-installable wheels. Today \`pip install shfmt-py\` downloads the shfmt binary from GitHub at install time, which breaks in airgapped/firewalled environments and slows CI.

Companion goal: also exercise the new wheel build on **every PR**, so a wheel-build regression surfaces pre-merge instead of post-release-tag.

## What

\`python-publish.yml\` now has 3 jobs and 3 triggers:

\`\`\`
on: pull_request | push to master | release: published

build-wheels (matrix) ──┐
build-sdist ────────────┤───► publish (only when event=release)
\`\`\`

### Wheel matrix (Phase 1, 5 platforms)

| Runner | Wheel tag |
|---|---|
| \`ubuntu-latest\` | \`manylinux2014_x86_64\` |
| \`ubuntu-24.04-arm\` | \`manylinux2014_aarch64\` |
| \`macos-latest\` (ARM) | \`macosx_11_0_arm64\` |
| \`macos-15-intel\` | \`macosx_10_9_x86_64\` |
| \`windows-latest\` | \`win_amd64\` |

\`_PYTHON_HOST_PLATFORM\` widens the linux/macos platform tags. shfmt binaries are statically-linked Go, so claiming broad compat is honest.

The sdist still gets built and (on release) PyPI-published, as a fallback for linux_arm 32-bit / windows_386.

### Shift-left

Before: wheel build only ran on \`release: published\`. A wheel-build regression would only show up *after* the tag was pushed — usually too late to back out cleanly.

After: every PR and master-push exercises the full matrix. The \`publish\` job is gated by \`if: github.event_name == 'release'\` so PyPI uploads still happen only on real releases.

## Self-testing

This PR itself will exercise the new matrix — if any of the 5 runners fail, that's the CI signal we wanted before release-time.

## Verified locally

\`python -m build --wheel\` produces \`shfmt_py-VERSION-py2.py3-none-linux_aarch64.whl\` with the shfmt binary at \`.data/scripts/shfmt\`.

## Out of scope

- linux_arm (32-bit) and windows_386 wheels — phase 2 if anyone asks.
- Migration to PyPI Trusted Publishing (OIDC) — separate concern, discussed in chat.