### PR TITLE
Fix README-sync workflow: drop PAT, use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/sync_readme_to_release.yml
+++ b/.github/workflows/sync_readme_to_release.yml
@@ -25,9 +25,11 @@ jobs:
 
       - uses: peter-evans/create-pull-request@v8
         with:
-          # PAT (not GITHUB_TOKEN) so the resulting PR triggers downstream
-          # CI workflows. GH suppresses workflow runs caused by GITHUB_TOKEN.
-          token: ${{ secrets.PAT }}
+          # Uses the default GITHUB_TOKEN (job permissions above grant
+          # contents:write and pull-requests:write). The auto-opened PR
+          # will not trigger downstream CI workflows — accepted trade-off
+          # for a README-rev-only change. Previously used secrets.PAT but
+          # that token lacked pull_requests:write scope.
           branch: sync-readme-to-release
           delete-branch: true
           title: "Sync README rev to ${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Why

The release-time README-sync workflow failed on the v3.13.0.2 publish:

\`\`\`
Resource not accessible by personal access token
  https://docs.github.com/rest/pulls/pulls#create-a-pull-request
\`\`\`

(Run: [actions/runs/25787481741](https://github.com/MaxWinterstein/shfmt-py/actions/runs/25787481741))

\`secrets.PAT\` doesn't have the \`pull_requests:write\` scope, so \`peter-evans/create-pull-request@v8\` can't create the PR.

## What

Drop \`token: \${{ secrets.PAT }}\` from the \`peter-evans\` step. The action defaults to \`GITHUB_TOKEN\`, and the workflow already declares \`permissions: pull-requests: write\` + \`contents: write\` at the job level — that's sufficient.

## Trade-off

PRs created with \`GITHUB_TOKEN\` don't trigger downstream workflows (GH's recursion guard). The auto-opened README-sync PR won't run the \`main\` test matrix. That's fine for a one-line README rev change — the matrix only validates \`shfmt --version\` works, which a README edit can't break.

If we ever need downstream CI on this auto-opened PR, the options are:
- update \`secrets.PAT\` to a fine-grained PAT with \`pull_requests:write\`, or
- switch to a GitHub App token

## Testing

This workflow only fires on \`release: published\`, so the fix won't be exercised until the next release. The error is mechanical and well-understood; reasonable to trust the fix.