### PR TITLE
Fall back to system shfmt on unsupported platforms (+ tests)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - run: pip install .
+      - run: pip install ".[test]"
+      - run: pytest tests/
       - run: shfmt --version
       - run: shfmt --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.egg-info/
+build/
+dist/
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: name-tests-test
+        args: [--pytest-test-first]  # we use pytest convention: test_*.py
     -   id: requirements-txt-fixer
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,10 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # setuptools is a build-time dep but not a runtime dep, so it isn't in the
 # venv after `pip install`. Tests load setup.py (which imports setuptools)
-# via importlib, so they need it explicitly.
-test = ["pytest>=7", "setuptools"]
+# via importlib, so they need it explicitly. Version floor matches the
+# build-system requirement — setuptools.command.build (used in setup.py)
+# was added in 62, and we already declare >=64 above.
+test = ["pytest>=7", "setuptools>=64"]
 
 [project.urls]
 Homepage = "https://github.com/maxwinterstein/shfmt-py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest>=7"]
+# setuptools is a build-time dep but not a runtime dep, so it isn't in the
+# venv after `pip install`. Tests load setup.py (which imports setuptools)
+# via importlib, so they need it explicitly.
+test = ["pytest>=7", "setuptools"]
 
 [project.urls]
 Homepage = "https://github.com/maxwinterstein/shfmt-py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
 [project.urls]
 Homepage = "https://github.com/maxwinterstein/shfmt-py"
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import hashlib
 import http
+import logging
 import os.path
 import platform
+import shutil
 import stat
 import sys
 import urllib.request
@@ -113,10 +115,36 @@ class fetch_binaries(Command):
         self.set_undefined_options("build", ("build_temp", "build_temp"))
 
     def run(self):
-        # save binary to self.build_temp
-        url, sha256 = get_download_url()
+        # Try the pre-built binary for this platform first; fall back to a
+        # system-installed shfmt on PATH if the platform isn't in the
+        # download manifest (e.g. FreeBSD, illumos).
+        try:
+            url, sha256 = get_download_url()
+        except KeyError:
+            self._fall_back_to_path_shfmt()
+            return
         data = download(url, sha256)
         save_executable(data, self.build_temp)
+
+    def _fall_back_to_path_shfmt(self):
+        plat = f"{sys.platform}:{platform.machine()}"
+        self.announce(
+            f"No pre-built shfmt for {plat}; looking for one on PATH",
+            level=logging.WARNING,
+        )
+        system_shfmt = shutil.which("shfmt")
+        if system_shfmt is None:
+            raise RuntimeError(
+                f"No pre-built shfmt for {plat} and no `shfmt` found on PATH. "
+                f"Install shfmt manually (e.g. via your OS package manager) and retry.",
+            )
+        exe_name = "shfmt.exe" if sys.platform == "win32" else "shfmt"
+        os.makedirs(self.build_temp, exist_ok=True)
+        shutil.copy2(system_shfmt, os.path.join(self.build_temp, exe_name))
+        self.announce(
+            f"Using {system_shfmt} as shfmt source for this build",
+            level=logging.INFO,
+        )
 
 
 class install_shfmt(Command):

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,30 @@ def save_executable(data: bytes, base_dir: str):
     os.chmod(output_path, mode)
 
 
+logger = logging.getLogger(__name__)
+
+
+def fall_back_to_path_shfmt(build_temp: str) -> None:
+    """Copy a system-installed shfmt into build_temp.
+
+    Used when the current platform has no pre-built binary in
+    POSTFIX_SHA256 (e.g. FreeBSD). Raises RuntimeError if no
+    shfmt is found on PATH either.
+    """
+    plat = f"{sys.platform}:{platform.machine()}"
+    logger.warning("No pre-built shfmt for %s; looking for one on PATH", plat)
+    system_shfmt = shutil.which("shfmt")
+    if system_shfmt is None:
+        raise RuntimeError(
+            f"No pre-built shfmt for {plat} and no `shfmt` found on PATH. "
+            f"Install shfmt manually (e.g. via your OS package manager) and retry.",
+        )
+    exe_name = "shfmt.exe" if sys.platform == "win32" else "shfmt"
+    os.makedirs(build_temp, exist_ok=True)
+    shutil.copy2(system_shfmt, os.path.join(build_temp, exe_name))
+    logger.info("Using %s as shfmt source for this build", system_shfmt)
+
+
 class build(orig_build):
     sub_commands = orig_build.sub_commands + [("fetch_binaries", None)]
 
@@ -121,30 +145,10 @@ class fetch_binaries(Command):
         try:
             url, sha256 = get_download_url()
         except KeyError:
-            self._fall_back_to_path_shfmt()
+            fall_back_to_path_shfmt(self.build_temp)
             return
         data = download(url, sha256)
         save_executable(data, self.build_temp)
-
-    def _fall_back_to_path_shfmt(self):
-        plat = f"{sys.platform}:{platform.machine()}"
-        self.announce(
-            f"No pre-built shfmt for {plat}; looking for one on PATH",
-            level=logging.WARNING,
-        )
-        system_shfmt = shutil.which("shfmt")
-        if system_shfmt is None:
-            raise RuntimeError(
-                f"No pre-built shfmt for {plat} and no `shfmt` found on PATH. "
-                f"Install shfmt manually (e.g. via your OS package manager) and retry.",
-            )
-        exe_name = "shfmt.exe" if sys.platform == "win32" else "shfmt"
-        os.makedirs(self.build_temp, exist_ok=True)
-        shutil.copy2(system_shfmt, os.path.join(self.build_temp, exe_name))
-        self.announce(
-            f"Using {system_shfmt} as shfmt source for this build",
-            level=logging.INFO,
-        )
 
 
 class install_shfmt(Command):
@@ -197,4 +201,5 @@ else:
 
     command_overrides["bdist_wheel"] = bdist_wheel
 
-setup(cmdclass=command_overrides)
+if __name__ == "__main__":
+    setup(cmdclass=command_overrides)

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,13 @@ def fall_back_to_path_shfmt(build_temp: str) -> None:
             f"No pre-built shfmt for {plat} and no `shfmt` found on PATH. "
             f"Install shfmt manually (e.g. via your OS package manager) and retry.",
         )
+    # On Windows, shutil.which honors PATHEXT and could find shfmt.bat / .cmd
+    # / .com etc. Renaming any of those to shfmt.exe produces a file Windows
+    # refuses to execute.
+    if sys.platform == "win32" and not system_shfmt.lower().endswith(".exe"):
+        raise RuntimeError(
+            f"Found {system_shfmt} on PATH, but it isn't a .exe; install the official shfmt.exe for Windows and retry.",
+        )
     exe_name = "shfmt.exe" if sys.platform == "win32" else "shfmt"
     os.makedirs(build_temp, exist_ok=True)
     shutil.copy2(system_shfmt, os.path.join(build_temp, exe_name))

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,66 @@
+"""Tests for the FreeBSD-style PATH fallback in setup.py.
+
+setup.py is loaded via importlib (rather than `import setup`) so we can give
+the module its own name and avoid colliding with anything else in sys.modules.
+The `if __name__ == "__main__":` guard at the bottom of setup.py keeps the
+real setup() call from running during these tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+SETUP_PY = Path(__file__).parent.parent / "setup.py"
+
+
+def _load_setup_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("setup_under_test", SETUP_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def setup_mod() -> types.ModuleType:
+    return _load_setup_module()
+
+
+def _exe_basename() -> str:
+    return "shfmt.exe" if sys.platform == "win32" else "shfmt"
+
+
+def test_fallback_copies_system_shfmt(setup_mod, tmp_path, monkeypatch):
+    """When the platform is unsupported but shfmt is on PATH, copy it to build_temp."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_shfmt = bin_dir / _exe_basename()
+    fake_shfmt.write_text("#!/bin/sh\necho fake-shfmt\n")
+    fake_shfmt.chmod(0o755)
+
+    monkeypatch.setenv("PATH", str(bin_dir))
+    if sys.platform == "win32":
+        monkeypatch.setenv("PATHEXT", ".EXE")
+
+    build_temp = tmp_path / "build"
+    setup_mod.fall_back_to_path_shfmt(str(build_temp))
+
+    copied = build_temp / _exe_basename()
+    assert copied.exists(), "fall_back_to_path_shfmt did not copy the binary"
+    assert copied.read_text() == fake_shfmt.read_text(), "copy is not byte-identical"
+
+
+def test_fallback_raises_when_no_shfmt_on_path(setup_mod, tmp_path, monkeypatch):
+    """When neither the platform manifest nor PATH has shfmt, raise a clear error."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("PATH", str(empty))
+    if sys.platform == "win32":
+        monkeypatch.setenv("PATHEXT", ".EXE")
+
+    with pytest.raises(RuntimeError, match=r"no `shfmt` found on PATH"):
+        setup_mod.fall_back_to_path_shfmt(str(tmp_path / "build"))

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -51,7 +51,7 @@ def test_fallback_copies_system_shfmt(setup_mod, tmp_path, monkeypatch):
 
     copied = build_temp / _exe_basename()
     assert copied.exists(), "fall_back_to_path_shfmt did not copy the binary"
-    assert copied.read_text() == fake_shfmt.read_text(), "copy is not byte-identical"
+    assert copied.read_bytes() == fake_shfmt.read_bytes(), "copy is not byte-identical"
 
 
 def test_fallback_raises_when_no_shfmt_on_path(setup_mod, tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

\`pip install shfmt-py\` on a platform not in \`POSTFIX_SHA256\` (FreeBSD, illumos, …) currently fails with an unhandled \`KeyError\`. No graceful degradation.

Re-implements the idea from [PR #15](https://github.com/MaxWinterstein/shfmt-py/pull/15) (credit: @kalaverin) cleanly against current master. The original has 5 months of bitrot; this is a focused subset.

## What

| Layer | Change |
|---|---|
| **setup.py** — fallback logic | New module-level \`fall_back_to_path_shfmt(build_temp)\`. Uses stdlib \`shutil.which()\` and \`shutil.copy2()\`. Clear \`RuntimeError\` when no fallback works. Wrap \`setup()\` in \`if __name__ == "__main__":\` so the file is importable for tests. |
| **tests/test_fallback.py** — new | Two pytest tests: ✅ copies system shfmt to build_temp; ✅ raises clean \`RuntimeError\` when PATH is empty. |
| **pyproject.toml** | \`[project.optional-dependencies] test = ["pytest>=7"]\` |
| **.github/workflows/main.yml** | \`pip install ".[test]" && pytest tests/\` runs in the full 5-OS × 3-Python matrix. |
| **.gitignore** — new | Ignore \`__pycache__\`, \`.pytest_cache\`, \`build/\`, \`dist/\`, \`*.egg-info\`. Was missing entirely before. |

## Fallback flow

\`\`\`
get_download_url() → KeyError?
  → no:   download pre-built binary (current behavior)
  → yes:  shutil.which("shfmt")
            → found:     shutil.copy2 to build_temp
            → not found: RuntimeError with platform info
\`\`\`

## Verified

| | |
|---|---|
| Happy path (linux/aarch64) — \`python -m build --wheel\` | ✅ downloads pre-built binary, builds wheel |
| Fallback path (test_fallback_copies_system_shfmt) | ✅ passes |
| No-fallback path (test_fallback_raises_when_no_shfmt_on_path) | ✅ passes with the documented error message |
| \`ruff check\` + \`ruff format\` | ✅ clean |

## What this PR is not

- Doesn't promise that an arbitrary system \`shfmt\` is the right *version* — if you install shfmt-py 3.13.0 on FreeBSD with shfmt 3.10.0 on PATH, the install succeeds with whatever's there. Version-pinning is out of scope.
- Doesn't take the unrelated changes from PR #15 (pre-commit reformats, Python 3.8 cap, \`yamlfix\`). Those would regress the recent modernization.

## After merge

PR #15 can be closed with a polite comment thanking @kalaverin and linking here.