### PR TITLE
Decouple shfmt-py versioning from upstream shfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,28 @@ Sample `.pre-commit-config.yaml`:
     - id: shfmt
 ```
 
+## Versioning
+
+`shfmt-py` is independently versioned. The PyPI version does **not** directly
+mirror the bundled `shfmt` version — check each GitHub release's notes for the
+exact `shfmt` version that release bundles.
+
+- **Major** — breaking change to `shfmt-py` itself (e.g. dropping a Python
+  version, renaming the pre-commit hook id).
+- **Minor** — new upstream `shfmt` release bundled.
+- **Patch** — wrapper-only fix (hash regeneration, CI changes affecting users,
+  etc.).
+
+Releases `3.x.y.z` and earlier used a 4-segment scheme aligned with upstream
+`shfmt`. From `v4.0.0` onwards `shfmt-py` follows standard semver.
+
 ## FAQ
 
 Q: It won't get updated via e.g. `Renovate Bot`
 
-A: See https://github.com/shfmt-py/update-via-renovate .
+A: Releases `v4.0.0` and onwards use standard semver — no special Renovate
+config needed. For older `3.x.y.z` releases you'll need
+`"versioning": "pep440"` (or see https://github.com/shfmt-py/update-via-renovate).
 
 Q: I get something like `SSL: CERTIFICATE_VERIFY_FAILED` on macOS
 


### PR DESCRIPTION
## Why

Today's 4-segment scheme `MAJOR.MINOR.PATCH.WRAPPER` (e.g. `3.13.0.2`):
- isn't standard semver — 3-segment tooling needs special config
- confuses Renovate downstream (requires `versioning: "loose"` or `"pep440"`)
- carries upstream `shfmt`'s numbering shape forever

Switch to independent semver:

- **Major** — `shfmt-py` breaking change (drop a Python version, rename hook id, etc.)
- **Minor** — new upstream `shfmt` release bundled
- **Patch** — wrapper-only fix

## What

Documentation only — no code changes. `setuptools-scm` already reads whatever tag we push.

- README: new **Versioning** section explaining the scheme.
- README FAQ: Renovate entry updated to reflect that `v4.0.0`+ needs no special config; old `3.x.y.z` still needs `pep440`.

## Next release should be `v4.0.0`

Above the existing `3.13.0.x` line to preserve PyPI ordering. From there, future tags follow the scheme above.

## What this PR is not

- Not a re-tagging of existing releases. The `3.x.y.z` versions on PyPI stay where they are.
- Not a fix for old users — they still see the `pep440` note in the FAQ.
- The [shfmt-py/update-via-renovate](https://github.com/shfmt-py/update-via-renovate) workaround repo can stay (still useful for `3.x` consumers) or be archived after a transition period.