### PR TITLE
README: reflect that wheels are the default install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Python-installable wrapper for [shfmt], the shell script formatter.
 
-Internally this package downloads the pre-built `shfmt` binary for your platform at install time.
+For most platforms, the pre-built `shfmt` binary is bundled in a wheel and `pip install` does not need network access. On platforms without a pre-built wheel, the sdist fallback downloads the binary at install time (or copies one from your `PATH` if no pre-built is available, e.g. on FreeBSD).
 
 Modeled after [shellcheck-py], adapted for `shfmt`.
 


### PR DESCRIPTION
## Why

Spotted by @MaxWinterstein: the README's lead-in says "Internally this package downloads the pre-built shfmt binary for your platform at install time." That was true historically but is now inaccurate.

After #52 (wheels) and #56 (PATH fallback), there are three install paths:

1. **Wheel** (most users) — binary is already inside; no install-time network.
2. **sdist + download** — for platforms not covered by a wheel (`linux_arm` 32-bit, `windows_386`). Same as old behavior.
3. **sdist + PATH fallback** — when neither a wheel nor a pre-built sdist target exists (FreeBSD, illumos, etc.). Copies a system `shfmt`.

## What

Rewrite the lead-in to put wheels first and treat install-time download as the fallback.