### PR TITLE
Fix FutureWarning from standalone 'wheel' package during installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=70.1", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -25,8 +25,8 @@ dynamic = ["version"]
 # venv after `pip install`. Tests load setup.py (which imports setuptools)
 # via importlib, so they need it explicitly. Version floor matches the
 # build-system requirement — setuptools.command.build (used in setup.py)
-# was added in 62, and we already declare >=64 above.
-test = ["pytest>=7", "setuptools>=64"]
+# was added in 62, and we already declare >=70.1 above.
+test = ["pytest>=7", "setuptools>=70.1"]
 
 [project.urls]
 Homepage = "https://github.com/maxwinterstein/shfmt-py"

--- a/setup.py
+++ b/setup.py
@@ -190,10 +190,16 @@ command_overrides = {
 
 
 try:
-    from wheel.bdist_wheel import bdist_wheel as orig_bdist_wheel
+    # setuptools >= 70.1 ships bdist_wheel directly; prefer it to avoid the
+    # FutureWarning emitted by the standalone 'wheel' package.
+    from setuptools.command.bdist_wheel import bdist_wheel as orig_bdist_wheel
 except ImportError:
-    pass
-else:
+    try:
+        from wheel.bdist_wheel import bdist_wheel as orig_bdist_wheel
+    except ImportError:
+        orig_bdist_wheel = None
+
+if orig_bdist_wheel is not None:
 
     class bdist_wheel(orig_bdist_wheel):
         def finalize_options(self):


### PR DESCRIPTION
As per the sole commit:

> When installing, pip's isolated build environment may include the standalone `wheel` package, which emits this warning:
>
>     ...site-packages/setuptools/_vendor/wheel/bdist_wheel.py:4: FutureWarning:
>     The 'wheel' package is no longer the canonical location of the
>     'bdist_wheel' command, and will be removed in a future release. Please
>     update to setuptools v70.1 or later which contains an integrated version of
>     this command.
>
> The warning originates in setup.py, which previously imported `bdist_wheel` directly from `wheel.bdist_wheel` (the deprecated standalone package).
>
> Two changes address this:
>
> - Bump the minimum setuptools version to 70.1 in `pyproject.toml` (setuptools >=70.1 ships `bdist_wheel` as a built-in command)
>
> - Update `setup.py` to prefer `setuptools.command.bdist_wheel` and only fall back to the standalone `wheel` package if that import fails
