### PR TITLE
Import bdist_wheel unconditionally and cover the wheel tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # setuptools is a build-time dep but not a runtime dep, so it isn't in the
 # venv after `pip install`. Tests load setup.py (which imports setuptools)
-# via importlib, so they need it explicitly. Version floor matches the
-# build-system requirement — setuptools.command.build (used in setup.py)
-# was added in 62, and we already declare >=70.1 above.
+# via importlib, so they need it explicitly. The floor is not optional here:
+# setup.py imports setuptools.command.bdist_wheel unconditionally, which only
+# exists from 70.1 on, matching the build-system requirement above.
 test = ["pytest>=7", "setuptools>=70.1"]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ import sys
 import urllib.request
 
 from setuptools import Command, setup
+from setuptools.command.bdist_wheel import bdist_wheel as orig_bdist_wheel
 from setuptools.command.build import build as orig_build
 from setuptools.command.install import install as orig_install
 
@@ -181,38 +182,30 @@ class install_shfmt(Command):
         return self.outfiles
 
 
+# orig_bdist_wheel is imported unconditionally at the top of this file: the
+# build-system requires setuptools>=70.1, which ships bdist_wheel as a built-in
+# command. Guarding that import would silently skip the overrides below and
+# produce a pure-python wheel that ships the binary under a py3-none-any tag;
+# failing loudly on a missing import is the safer trade.
+class bdist_wheel(orig_bdist_wheel):
+    def finalize_options(self):
+        orig_bdist_wheel.finalize_options(self)
+        # Mark us as not a pure python package
+        self.root_is_pure = False
+
+    def get_tag(self):
+        _, _, plat = orig_bdist_wheel.get_tag(self)
+        # We don't contain any python source, nor any python extensions
+        return "py2.py3", "none", plat
+
+
 command_overrides = {
     "install": install,
     "install_shfmt": install_shfmt,
     "build": build,
     "fetch_binaries": fetch_binaries,
+    "bdist_wheel": bdist_wheel,
 }
-
-
-try:
-    # setuptools >= 70.1 ships bdist_wheel directly; prefer it to avoid the
-    # FutureWarning emitted by the standalone 'wheel' package.
-    from setuptools.command.bdist_wheel import bdist_wheel as orig_bdist_wheel
-except ImportError:
-    try:
-        from wheel.bdist_wheel import bdist_wheel as orig_bdist_wheel
-    except ImportError:
-        orig_bdist_wheel = None
-
-if orig_bdist_wheel is not None:
-
-    class bdist_wheel(orig_bdist_wheel):
-        def finalize_options(self):
-            orig_bdist_wheel.finalize_options(self)
-            # Mark us as not a pure python package
-            self.root_is_pure = False
-
-        def get_tag(self):
-            _, _, plat = orig_bdist_wheel.get_tag(self)
-            # We don't contain any python source, nor any python extensions
-            return "py2.py3", "none", plat
-
-    command_overrides["bdist_wheel"] = bdist_wheel
 
 if __name__ == "__main__":
     setup(cmdclass=command_overrides)

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -1,0 +1,59 @@
+"""Tests for the bdist_wheel overrides in setup.py.
+
+This distribution ships a prebuilt shfmt binary and no Python source, so the
+wheel must be tagged `py2.py3-none-<platform>`. If the overrides ever stop
+being registered, the wheel silently becomes `py3-none-any` and the binary
+gets published as if it were pure Python — these tests guard that tag.
+
+See tests/test_fallback.py for why setup.py is loaded via importlib.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+import pytest
+from setuptools.dist import Distribution
+
+SETUP_PY = Path(__file__).parent.parent / "setup.py"
+
+
+def _load_setup_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("setup_under_test", SETUP_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def setup_mod() -> types.ModuleType:
+    return _load_setup_module()
+
+
+@pytest.fixture
+def wheel_cmd(setup_mod):
+    dist = Distribution({"name": "shfmt-py", "version": "0.0.0"})
+    cmd = setup_mod.bdist_wheel(dist)
+    cmd.finalize_options()
+    return cmd
+
+
+def test_bdist_wheel_override_is_registered(setup_mod):
+    """setup() must receive our subclass, not setuptools' stock command."""
+    assert setup_mod.command_overrides["bdist_wheel"] is setup_mod.bdist_wheel
+
+
+def test_wheel_is_not_pure_python(wheel_cmd):
+    """root_is_pure=False is what keeps the platform tag off `any`."""
+    assert wheel_cmd.root_is_pure is False
+
+
+def test_tag_is_platform_specific_and_version_agnostic(wheel_cmd):
+    """No Python source and no extensions, so the wheel works on any interpreter."""
+    python_tag, abi_tag, platform_tag = wheel_cmd.get_tag()
+
+    assert python_tag == "py2.py3"
+    assert abi_tag == "none"
+    assert platform_tag != "any", "binary distribution must not be tagged as pure Python"


### PR DESCRIPTION
Follow-up to #66, which raised the setuptools floor to `>=70.1` so `bdist_wheel` comes from setuptools instead of the deprecated standalone `wheel` package.

With that floor in place, the remaining guarded import is dead code under build isolation — and it has a silent failure mode. If *both* imports fail, `orig_bdist_wheel` is `None`, the override is skipped, and the wheel is built as `py3-none-any`: the shfmt binary would be published as if it were pure Python, installable on every platform and broken on most of them. Nothing in CI catches that, because the build still succeeds.

Three changes:

- **Import `setuptools.command.bdist_wheel` unconditionally**, at the top of `setup.py` next to the other setuptools command imports. A missing import now fails loudly at build time instead of quietly mistagging the wheel.
- **Fold the override into the `command_overrides` literal**, now that it is no longer conditional.
- **Add `tests/test_bdist_wheel.py`** — the tag had no coverage at all. It asserts the override is registered, that `root_is_pure` stays `False`, and that `get_tag()` returns a platform-specific `py2.py3`/`none` tag.

Also refreshed the `test` extra comment in `pyproject.toml`: the floor is now load-bearing for `setup.py`, not just mirroring the build-system requirement.

### Verification

Built end-to-end locally, tag unchanged from what CI produces on master:

```
_PYTHON_HOST_PLATFORM=manylinux2014_x86_64 python -m build --wheel
Successfully built shfmt_py-4.0.1.dev9-py2.py3-none-manylinux2014_x86_64.whl
```

`ruff check`, `ruff format` and `pytest tests/` (5 passed) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
