### PR TITLE
Smoke-test the release artifacts before publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -73,8 +73,113 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
-  publish:
+  # The jobs above only prove the artifacts *build*. Nothing so far installs
+  # them or runs the binary they ship, so a wheel that is mistagged or missing
+  # shfmt would go straight to PyPI. These two jobs gate `publish` on the
+  # artifacts actually working, on the same platform they are tagged for.
+  smoke-test-wheels:
+    needs: [build-wheels]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: wheel-linux_x86_64
+            expected_tag: py2.py3-none-manylinux2014_x86_64
+          - os: ubuntu-24.04-arm
+            artifact: wheel-linux_aarch64
+            expected_tag: py2.py3-none-manylinux2014_aarch64
+          - os: macos-latest
+            artifact: wheel-macos_arm64
+            expected_tag: py2.py3-none-macosx_11_0_arm64
+          - os: macos-15-intel
+            artifact: wheel-macos_x86_64
+            expected_tag: py2.py3-none-macosx_10_9_x86_64
+          - os: windows-latest
+            artifact: wheel-windows_amd64
+            expected_tag: py2.py3-none-win_amd64
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.x"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist
+      - name: Check the wheel tag
+        # A pure-python `py3-none-any` tag installs everywhere and would only
+        # be noticed once someone downloads it on the wrong platform, so pin
+        # the expected tag rather than trusting pip's compatibility check.
+        env:
+          EXPECTED_TAG: ${{ matrix.expected_tag }}
+        run: |
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one wheel, got ${#wheels[@]}: ${wheels[*]}"
+            exit 1
+          fi
+          name=$(basename "${wheels[0]}")
+          echo "wheel: $name"
+          case "$name" in
+            *-"$EXPECTED_TAG".whl) echo "tag matches $EXPECTED_TAG" ;;
+            *) echo "::error::wheel tag mismatch: expected *-$EXPECTED_TAG.whl, got $name"; exit 1 ;;
+          esac
+      - name: Install the wheel
+        # --no-index / --only-binary keeps pip from quietly rebuilding from
+        # source: whatever runs below is the artifact we are about to publish.
+        run: |
+          python -m pip install --no-index --only-binary=:all: --find-links dist shfmt-py
+      - name: Run the shfmt it ships
+        run: |
+          shfmt --version
+          expected=$(python -c "import re, pathlib; print(re.search(r'SHFMT_VERSION = \"([^\"]+)\"', pathlib.Path('setup.py').read_text())[1])")
+          actual=$(shfmt --version)
+          if [ "$actual" != "v$expected" ]; then
+            echo "::error::wheel ships shfmt $actual, but setup.py pins v$expected"
+            exit 1
+          fi
+      - name: Format a real script with it
+        run: |
+          printf '#!/bin/sh\nif [ -n "$1" ]; then\necho "hello $1"\nfi\n' > messy.sh
+          shfmt -w messy.sh
+          cat messy.sh
+          # -d exits non-zero if anything is still unformatted
+          shfmt -d messy.sh
+
+  smoke-test-sdist:
     needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.x"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Validate the metadata PyPI will render
+        run: |
+          python -m pip install twine
+          twine check dist/*
+      - name: Install from the sdist and run it
+        # Naming the tarball explicitly makes pip build it from source, which
+        # is the path a user without a matching wheel would hit.
+        run: |
+          python -m pip install dist/*.tar.gz
+          shfmt --version
+
+  publish:
+    needs: [build-wheels, build-sdist, smoke-test-wheels, smoke-test-sdist]
     # Only actually publish on real release events; the build matrix above
     # still runs on every PR / push to catch wheel-build regressions early.
     if: github.event_name == 'release'


### PR DESCRIPTION
`build-wheels` and `build-sdist` only prove the artifacts *build*. Nothing installs them or runs the binary they ship — the wheels go from `upload-artifact` straight to `download-artifact` to PyPI. A wheel that built fine but was mistagged, or shipped no shfmt at all, would be published unnoticed.

The `test` job in `main.yml` does not cover this: a pure-python `py3-none-any` wheel installs perfectly well on the machine that built it, so the mistag only shows up once someone downloads it on the wrong platform.

Two new jobs, which `publish` now depends on:

**`smoke-test-wheels`** — matrix over all five platforms, each wheel tested on a runner of *its own* platform:

- Asserts the filename carries the expected `py2.py3-none-<platform>` tag. Deliberately pinned rather than relying on pip's compatibility check, which would happily accept `py3-none-any`.
- Installs with `--no-index --only-binary=:all:` so pip cannot quietly rebuild from source — what runs below is the artifact we are about to publish.
- Checks the shfmt it ships reports the version `setup.py` pins, catching a wheel built with a stale binary.
- Formats a real script: `shfmt -w`, then `shfmt -d`, which exits non-zero if anything is left unformatted.

**`smoke-test-sdist`** — runs `twine check` over every artifact so broken metadata fails here instead of at the PyPI upload, then installs from the sdist to exercise the build-from-source path.

### Verification

The shell logic was run locally against real wheels built from this repo before opening the PR:

- correct wheel vs. its expected tag → pass
- a simulated `shfmt_py-…-py3-none-any.whl` → **rejected**, which is the failure mode this is meant to catch
- version assertion, `shfmt -w` + `shfmt -d`, and `twine check` on a real wheel and sdist → all pass

The workflow triggers on `pull_request`, so the new jobs run on this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
