### PR TITLE
Rewrite README around the questions users actually arrive with

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 `pip install shfmt-py` puts [shfmt], the shell script formatter, on the `PATH` of your Python
 environment and gives you a ready-made [pre-commit] hook.
 
-This is packaging only. The binary is upstream's, unmodified — bundled inside the wheel on common
-platforms, downloaded and checksum-verified at build time otherwise ("How the binary gets installed"
-below has the details). There is no Python API: nothing to `import`, no `python -m shfmt`. For what
+This is packaging only — no patches, no Python API, nothing to `import`, no `python -m shfmt`. On
+common platforms the wheel bundles upstream's binary; elsewhere the build downloads and
+checksum-verifies it, or — where no build is pinned for your platform — copies an existing `shfmt`
+from your `PATH` unverified ("How the binary gets installed" below has the details). For what
 `shfmt` does and which flags it takes, run `shfmt --help` or read the [upstream docs][shfmt].
 
 Modeled after [shellcheck-py], adapted for `shfmt`.
@@ -73,7 +74,7 @@ Those flags — two-space indent, indented `case` arms, binary operators allowed
 are the set the upstream manual describes as closely resembling Google's shell style. Quote the `2`:
 pre-commit expects every argument to be a string, and YAML would otherwise make it an integer.
 
-For a check-only run that reports instead of rewriting, use these `args` in the same `hooks:` list:
+For a check-only run that reports instead of rewriting, swap the `args` above for:
 
 ```yaml
     - id: shfmt
@@ -143,7 +144,8 @@ source and still reaches for GitHub, so an air-gapped runner additionally needs 
 ## Versioning
 
 Which `shfmt` do you have? Ask the binary — `shfmt --version` is always right. Before installing,
-read `SHFMT_VERSION` in [setup.py] at the tag you are interested in.
+read `SHFMT_VERSION` in `setup.py` at that release's tag —
+`https://github.com/MaxWinterstein/shfmt-py/blob/vX.Y.Z/setup.py`.
 
 `shfmt-py` is independently versioned; the PyPI version does **not** mirror the bundled `shfmt`
 version.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Add to `.pre-commit-config.yaml`:
 the newest tag; `pre-commit run --all-files` formats the whole repository.
 
 The hook runs on every file [identify] tags as `shell`, excluding `csh` and `tcsh`. It defaults to
-`args: [-w]`, which rewrites files in place, and is marked `require_serial: true`, so pre-commit
-runs one `shfmt` process at a time instead of sharding files across workers.
+`args: [-w]`, which rewrites files in place.
 
 ### Overriding args
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,152 @@
 [![PyPI version](https://img.shields.io/pypi/v/shfmt-py.svg)](https://pypi.org/project/shfmt-py)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/shfmt-py.svg)](https://pypi.org/project/shfmt-py)
-[![Downloads](https://img.shields.io/pypi/dm/shfmt-py.svg)](https://pypi.org/project/shfmt-py)
-[![License](https://img.shields.io/github/license/MaxWinterstein/shfmt-py.svg)](https://github.com/MaxWinterstein/shfmt-py/blob/master/LICENSE)
+[![Downloads](https://static.pepy.tech/badge/shfmt-py/month)](https://pepy.tech/project/shfmt-py)
+[![License](https://img.shields.io/pypi/l/shfmt-py.svg)](https://github.com/MaxWinterstein/shfmt-py/blob/master/LICENSE)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/MaxWinterstein/shfmt-py/master.svg)](https://results.pre-commit.ci/latest/github/MaxWinterstein/shfmt-py/master)
 
 # shfmt-py
 
-Python-installable wrapper for [shfmt], the shell script formatter.
+`pip install shfmt-py` puts [shfmt], the shell script formatter, on the `PATH` of your Python
+environment and gives you a ready-made [pre-commit] hook.
 
-For most platforms, the pre-built `shfmt` binary is bundled in a wheel and `pip install` does not need network access. On platforms without a pre-built wheel, the sdist fallback downloads the binary at install time (or copies one from your `PATH` if no pre-built is available, e.g. on FreeBSD).
+This is packaging only. The binary is upstream's, unmodified — bundled inside the wheel on common
+platforms, downloaded and checksum-verified at build time otherwise ("How the binary gets installed"
+below has the details). There is no Python API: nothing to `import`, no `python -m shfmt`. For what
+`shfmt` does and which flags it takes, run `shfmt --help` or read the [upstream docs][shfmt].
 
 Modeled after [shellcheck-py], adapted for `shfmt`.
 
-## Installation
+## Install
 
 ```bash
 pip install shfmt-py
 ```
 
-## Usage
+Or as a standalone tool, isolated from any project environment:
 
-### CLI
+```bash
+uv tool install shfmt-py
+# or
+pipx install shfmt-py
+```
 
-After installation, the `shfmt` binary is available on your `PATH` (or `shfmt.exe` on Windows).
+Requires Python 3.9 or newer; the binary itself has no Python runtime dependency. CI covers
+CPython 3.9, 3.13 and 3.14 on Linux, macOS (arm64 and x86_64) and Windows.
 
-### As pre-commit hook
+The distribution installs exactly one executable — `shfmt`, or `shfmt.exe` on Windows — into the
+environment's scripts directory, so it is on `PATH` whenever that environment is active.
+`pip uninstall shfmt-py` removes it again.
 
-See [pre-commit] for instructions.
+## Pre-commit hook
 
-Sample `.pre-commit-config.yaml`:
+Add to `.pre-commit-config.yaml`:
 
 ```yaml
-- repo: https://github.com/maxwinterstein/shfmt-py
+- repo: https://github.com/MaxWinterstein/shfmt-py
   rev: v4.0.0
   hooks:
     - id: shfmt
 ```
 
+`rev` is the `shfmt-py` release tag, not the `shfmt` version. `pre-commit autoupdate` moves it to
+the newest tag; `pre-commit run --all-files` formats the whole repository.
+
+The hook runs on every file [identify] tags as `shell`, excluding `csh` and `tcsh`. It defaults to
+`args: [-w]`, which rewrites files in place, and is marked `require_serial: true`, so pre-commit
+runs one `shfmt` process at a time instead of sharding files across workers.
+
+### Overriding args
+
+pre-commit **replaces** the default `args`; it does not extend them. Drop `-w` by accident and
+`shfmt` prints the formatted script to stdout, changes nothing and exits 0 — the hook goes green
+while your files stay unformatted. So re-add it:
+
+```yaml
+- repo: https://github.com/MaxWinterstein/shfmt-py
+  rev: v4.0.0
+  hooks:
+    - id: shfmt
+      args: [-w, -i, "2", -ci, -bn] # -w must be re-added
+```
+
+Those flags — two-space indent, indented `case` arms, binary operators allowed to start a line —
+are the set the upstream manual describes as closely resembling Google's shell style. Quote the `2`:
+pre-commit expects every argument to be a string, and YAML would otherwise make it an integer.
+
+For a check-only run that reports instead of rewriting, use these `args` in the same `hooks:` list:
+
+```yaml
+    - id: shfmt
+      args: [-d] # print a diff and fail; no -w on purpose
+```
+
+### EditorConfig
+
+`shfmt` reads formatting options from `.editorconfig`. Two of its behaviors matter for hook users:
+
+- **Any parser or printer flag turns EditorConfig off entirely** — `-i`, `-ci`, `-s`, `-ln` and
+  friends disable every EditorConfig formatting option, not just the one you overrode. `-w`, `-d`
+  and `-l` are generic flags and leave it alone, so the default `args: [-w]` keeps `.editorconfig`
+  in charge. Configure your style in one place, not both.
+- **`ignore = true` is skipped for explicitly named files**, and pre-commit always names files
+  explicitly. Use `args: [-w, --apply-ignore]` to honor it, or pre-commit's own `exclude:`.
+
+### Hook installs need network access
+
+pre-commit installs `language: python` hooks by running `pip install .` inside its own clone, so it
+never uses the published wheels. Installing the hook therefore downloads the binary from the
+`mvdan/sh` GitHub release the first time a given `rev` is used, and caches the result afterwards.
+Restricted runners need `github.com` **and** its release-asset host (`*.githubusercontent.com`)
+reachable — a PyPI mirror is not enough.
+
+## Command line
+
+```bash
+shfmt --version    # the upstream version this release bundles
+shfmt -w script.sh # format in place
+shfmt -d .         # print a diff, exit 1 if anything differs
+shfmt -l .         # list files that differ, exit 1 if any do
+```
+
+`shfmt --help` prints the full flag list. Dialects, EditorConfig keys and the default style are
+upstream's documentation, not this project's: see [mvdan/sh][shfmt] and its
+[man page source][manual] (or run `man shfmt`).
+
+## How the binary gets installed
+
+Three paths, in this order:
+
+1. **A matching wheel.** Published for Linux x86_64 and aarch64 (manylinux2014), macOS arm64 and
+   x86_64, and Windows amd64. The binary is already inside the wheel, so nothing is fetched at
+   install time and a PyPI mirror is enough.
+2. **From source, platform in the download table.** The other platforms this package pins a
+   download for — 32-bit Windows, Linux armv7 (hosts whose `uname -m` reports `armv7l`), Cygwin,
+   and musl-based distros such as Alpine, which use the ordinary static Linux binaries — plus any
+   install that bypasses wheels (`pip install --no-binary :all: shfmt-py`, or pre-commit). The
+   build downloads the official release asset and verifies it against a sha256 pinned in
+   [setup.py]. A mismatch aborts the install, and if GitHub is unreachable the install fails rather
+   than silently using something else.
+3. **From source, platform not in the download table.** FreeBSD, illumos, 32-bit x86 Linux, older
+   32-bit ARM and other architectures with no pinned download here: the build copies whatever
+   `shfmt` it finds on your `PATH` (on Windows it must be a real `.exe`). That copy is neither
+   checksummed nor version-checked, so it may differ from the version this release pins —
+   `shfmt --version` is worth a look. With no `shfmt` on `PATH`, the install fails with an error
+   telling you to install one, instead of installing something broken.
+
+For air-gapped environments, build one wheel per target platform on a machine that can reach GitHub
+(`python -m build --wheel`; on Linux set `_PYTHON_HOST_PLATFORM=manylinux2014_x86_64`, as the
+release workflow does, or the wheel comes out tagged `linux_x86_64`) and serve them from your
+internal index. That covers `pip` / `uv` / `pipx` installs only: pre-commit builds the hook from
+source and still reaches for GitHub, so an air-gapped runner additionally needs a mirror of the
+`mvdan/sh` release asset or a pre-populated `~/.cache/pre-commit`.
+
 ## Versioning
 
-`shfmt-py` is independently versioned. The PyPI version does **not** directly
-mirror the bundled `shfmt` version — check each GitHub release's notes for the
-exact `shfmt` version that release bundles.
+Which `shfmt` do you have? Ask the binary — `shfmt --version` is always right. Before installing,
+read `SHFMT_VERSION` in [setup.py] at the tag you are interested in.
+
+`shfmt-py` is independently versioned; the PyPI version does **not** mirror the bundled `shfmt`
+version.
 
 - **Major** — breaking change to `shfmt-py` itself (e.g. dropping a Python
   version, renaming the pre-commit hook id).
@@ -49,24 +154,59 @@ exact `shfmt` version that release bundles.
 - **Patch** — wrapper-only fix (hash regeneration, CI changes affecting users,
   etc.).
 
-Releases `3.x.y.z` and earlier used a 4-segment scheme aligned with upstream
-`shfmt`. From `v4.0.0` onwards `shfmt-py` follows standard semver.
+Releases `3.x.y.z` and earlier used a 4-segment scheme aligned with upstream `shfmt` — `3.13.0.3`
+bundled `shfmt` 3.13.0. From `v4.0.0` onwards `shfmt-py` follows standard semver.
 
 ## FAQ
 
-Q: It won't get updated via e.g. `Renovate Bot`
+**The hook passes but nothing gets formatted.**
 
-A: Releases `v4.0.0` and onwards use standard semver — no special Renovate
-config needed. For older `3.x.y.z` releases you'll need
-`"versioning": "pep440"` (or see https://github.com/shfmt-py/update-via-renovate).
+You set `args:` without `-w`. pre-commit replaces the default `args: [-w]` instead of extending it,
+so re-add `-w` to your list.
 
-Q: I get something like `SSL: CERTIFICATE_VERIFY_FAILED` on macOS
+**`shfmt: command not found` after `pip install`.**
 
-A: Install certificates with e.g.: `"/Applications/Python 3.9/Install Certificates.command"`. See [here][here1] or [here][here2] for a solution.
+The executable lands in the target environment's scripts directory. Activate that virtualenv, or
+use `uv tool install shfmt-py` / `pipx install shfmt-py` to get it on your user `PATH`. If your OS
+package manager also ships `shfmt`, `PATH` order decides which one runs — `shfmt --version` tells
+you which one you got.
 
+**It won't get updated via e.g. `Renovate Bot`.**
+
+Releases `v4.0.0` and onwards use standard semver — no special Renovate config needed. For older
+`3.x.y.z` releases you'll need `"versioning": "pep440"` (or see
+[shfmt-py/update-via-renovate][renovate-example]). For the pre-commit hook, `pre-commit autoupdate`
+works either way.
+
+**I get something like `SSL: CERTIFICATE_VERIFY_FAILED` on macOS.**
+
+This only happens on the from-source paths that download from GitHub at build time — which include
+every pre-commit hook install — never when a wheel is used. Install certificates with e.g.
+`"/Applications/Python 3.x/Install Certificates.command"` for the Python you are installing with.
+See [this MerossIot comment][here1] or [this Stack Overflow answer][here2] for a solution.
+
+## Issues
+
+Formatting behavior, flags and feature requests belong upstream, at [mvdan/sh issues][sh-issues].
+Packaging, wheels, platform coverage and the hook definition belong in
+[this project's issue tracker][shfmt-py-issues].
+
+## License
+
+`shfmt-py` is MIT licensed; see [LICENSE]. The `shfmt` binary it ships or downloads is the work of
+the [mvdan/sh][shfmt] project and is redistributed unmodified under its own
+[BSD-3-Clause license][shfmt-license].
 
 [shfmt]: https://github.com/mvdan/sh
+[manual]: https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd
+[sh-issues]: https://github.com/mvdan/sh/issues
 [pre-commit]: https://pre-commit.com
+[identify]: https://github.com/pre-commit/identify
 [shellcheck-py]: https://github.com/shellcheck-py/shellcheck-py
+[setup.py]: https://github.com/MaxWinterstein/shfmt-py/blob/master/setup.py
+[shfmt-py-issues]: https://github.com/MaxWinterstein/shfmt-py/issues
+[LICENSE]: https://github.com/MaxWinterstein/shfmt-py/blob/master/LICENSE
+[shfmt-license]: https://github.com/mvdan/sh/blob/master/LICENSE
+[renovate-example]: https://github.com/shfmt-py/update-via-renovate
 [here1]: https://github.com/albertogeniola/MerossIot/issues/62#issuecomment-535769621
 [here2]: https://stackoverflow.com/questions/27835619/urllib-and-ssl-certificate-verify-failed-error


### PR DESCRIPTION
The README covered install and the pre-commit snippet, but left out the things that generate issues. This rewrite keeps everything of value and adds what was missing.

## What's new

- **Lead sets expectations up front** — packaging only, no Python API, formatting behaviour is upstream's business.
- **The `-w` trap.** pre-commit *replaces* the default `args: [-w]` rather than extending it. Drop `-w` and `shfmt` prints to stdout, changes nothing, exits 0 — the hook goes green while files stay unformatted.
- **EditorConfig interaction.** Any parser or printer flag (`-i`, `-ci`, `-s`, `-ln`) disables EditorConfig *entirely*, not just the option you overrode; `-w`/`-d`/`-l` are generic and leave it in charge. Plus `--apply-ignore` for `ignore = true`, which is skipped for explicitly named files — and pre-commit always names files explicitly.
- **Hook installs need network access.** pre-commit runs `python -mpip install .` in its own clone, so it never uses the published wheels and always downloads the binary from the `mvdan/sh` release on a new `rev`. Restricted runners need `github.com` *and* `*.githubusercontent.com`; a PyPI mirror is not enough.
- **New "How the binary gets installed" section** — the three resolution paths (matching wheel → pinned-sha256 download → copy from `PATH`), which platforms land on each (incl. Alpine/musl, Cygwin, 32-bit x86, FreeBSD), and what air-gapped environments need.
- **FAQ** gains "the hook passes but nothing gets formatted" and "`shfmt: command not found`". Both existing entries (Renovate, macOS SSL) are kept.

## Two badges were showing errors, not data

| Badge | Was rendering | Now |
| --- | --- | --- |
| License | `github/license` → "license: not identifiable by github" (LICENSE carries two copyright holders) | `pypi/l` → "license: MIT" |
| Downloads | `pypi/dm` → "downloads: rate limited by upstream service" | pepy |

Easy to revert if you'd rather keep shields for consistency — the shields backend may recover on its own.

## Verified, not assumed

Every non-obvious claim was checked against the real thing rather than from memory:

- Downloaded shfmt **v3.13.1** and reproduced the EditorConfig on/off behaviour and `--apply-ignore` semantics experimentally.
- `-i 2 -ci -bn` ≈ Google's shell style is upstream's own wording in `cmd/shfmt/shfmt.1.scd`.
- The "quote the `2`" note: pre-commit validates hook args with `cfgv.check_array(cfgv.check_string)` (`clientlib.py`).
- pre-commit's install command: `('python', '-mpip', 'install', '.', ...)` in `pre_commit/languages/python.py`.
- A built wheel really does ship `shfmt_py-*.data/scripts/shfmt`, which is what makes the `pipx` / `uv tool install` advice hold.
- The release asset redirects to `release-assets.githubusercontent.com`, confirming the allowlist note.

## Rendering and automation

- Renders cleanly through PyPI's `readme_renderer` (it's the `long_description`); no raw HTML, no GitHub-only syntax, no relative links, no in-page anchors.
- All 22 URLs resolve (Stack Overflow 403s bots only).
- The `sync_readme_to_release` sed still matches exactly the two `rev: v4.0.0` lines and rewrites both correctly — simulated with `TAG=v4.1.0`.
- No trailing whitespace, no tabs, single terminating newline.

Reviewing the rendered file is easier than the diff: https://github.com/MaxWinterstein/shfmt-py/blob/docs/readme-overhaul/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)