### PR TITLE
Drop require_serial from the shfmt hook, and cover the hook in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,70 @@ jobs:
       - run: pytest tests/
       - run: shfmt --version
       - run: shfmt --help
+
+  # Nothing else executes .pre-commit-hooks.yaml: the job above tests the
+  # binary, not the hook definition, so a broken entry/types/args would ship
+  # unnoticed. Run the hook the way a user gets it — pre-commit builds it from
+  # source and fetches the binary — over enough files that pre-commit shards
+  # them across workers, which is what makes running without require_serial
+  # meaningful. Windows is included because it resolves shfmt.exe instead.
+  hook:
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+      - run: python -m pip install pre-commit
+      - name: Run the hook against a sandbox repo
+        run: |
+          set -euo pipefail
+          repo="$PWD"
+          # Put the sandbox next to the checkout rather than in $TMPDIR. On
+          # Windows runners the workspace is on D: while mktemp lands on C:,
+          # and try-repo computes a relative path between the two, which fails
+          # with "ValueError: path is on mount 'D:', start on mount 'C:'".
+          sandbox="$repo/../hook-sandbox"
+          rm -rf "$sandbox"
+          mkdir -p "$sandbox"
+          cd "$sandbox"
+          git init -q .
+          git config user.email ci@example.com
+          git config user.name ci
+          python - <<'PY'
+          import pathlib
+          for i in range(60):
+              pathlib.Path(f"s{i:02d}.sh").write_text('#!/bin/sh\nif [ -n "$1" ]; then\necho "hi $1"\nfi\n')
+          PY
+          git add -A
+          git commit -qm fixtures
+
+          # First run must FAIL: the hook rewrites unformatted files.
+          if pre-commit try-repo "$repo" shfmt --all-files; then
+            echo "::error::hook reported success on unformatted files - it never ran, or -w was dropped"
+            exit 1
+          fi
+
+          # Every file must be formatted, not just whichever shard ran first.
+          tab_echo="$(printf '\techo')"
+          for f in s*.sh; do
+            if ! grep -q "$tab_echo" "$f"; then
+              echo "::error::$f was not formatted by the hook"
+              cat "$f"
+              exit 1
+            fi
+          done
+
+          # Second run must PASS: formatting is idempotent.
+          git add -A
+          git commit -qm formatted
+          pre-commit try-repo "$repo" shfmt --all-files

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,3 @@
   types: [shell]
   exclude_types: [csh, tcsh]
   args: [-w] # write file back
-  require_serial: true # shfmt can detect sourcing this way


### PR DESCRIPTION
`.pre-commit-hooks.yaml` justified `require_serial` with:

```yaml
require_serial: true # shfmt can detect sourcing this way
```

That rationale isn't shfmt's — it came over from shellcheck-py by search-and-replace, in `eef42c6` ("Initial change towards shfmt"):

```diff
-  require_serial: true # shellcheck can detect sourcing this way
+  require_serial: true # shfmt can detect sourcing this way
```

[shellcheck-py's hook](https://github.com/shellcheck-py/shellcheck-py/blob/main/.pre-commit-hooks.yaml) still carries the original, and there it means something: `shellcheck -x` follows sourced files. shfmt has no equivalent — it's a formatter, `shfmt --help` for v3.13.1 lists no such flag, and it reads nothing but the files it's handed.

## This is not a speedup

An earlier version of this PR claimed removing the flag "speeds the hook up on large repositories." That was asserted without measuring, and it's wrong.

**The common case is provably identical.** pre-commit's `partition()` uses `max_args = max(4, ceil(files/concurrency))`, so **up to 4 files produce a single partition either way** — the same lone `shfmt` process. That's the normal `pre-commit run` on staged files.

**At scale the difference is noise.** 60 files, 12 CPUs (12 partitions vs 1), five runs each:

| | seconds |
| --- | --- |
| parallel (no `require_serial`) | 3.06 2.94 3.08 3.29 3.02 |
| serial (`require_serial: true`) | 2.87 3.18 3.95 3.14 3.39 |

Fully overlapping, because of the ceiling: **shfmt formats all 60 files in 4–14 ms** in one invocation. Parallelism can save ~10 ms while adding 11 process spawns, against pre-commit's own ~3 s startup.

**So: users updating to the next release will see no difference.** The removal is hygiene — the repo shouldn't carry a constraint whose stated reason is untrue and whose real effect is nil — not an optimisation. No hazard justifies keeping it either: disjoint argv per process, read-only EditorConfig lookups, neither `--filename` nor stdin in play.

## Second commit: the hook had no test at all

**Nothing in this repo ever executed `.pre-commit-hooks.yaml`.** The `test` job installs the wheel and runs the binary, which says nothing about the hook definition; `entry`, `types`, `exclude_types` and `args` could all break and CI would stay green. The removal above had nothing verifying it.

The new `hook` job runs the hook as a user receives it — `pre-commit try-repo` builds it from source and fetches the binary — over 60 unformatted scripts. It asserts:

1. the first run **fails** and rewrites files (proving `-w` is in effect);
2. **every** file is formatted, not just whichever shard ran first;
3. a second run **passes** (idempotent).

**The test can fail.** Verified by changing `args` to `[]`: the hook reports `Passed` while leaving all 60 files unformatted — precisely the silently-green failure mode — and the job exits 1.

Windows is in the matrix because it resolves `shfmt.exe` differently, and it earned its place immediately: the sandbox originally came from `mktemp -d`, which lands on `C:` while the workspace is on `D:`, and `try-repo` relativises one against the other → `ValueError: path is on mount 'D:', start on mount 'C:'`. The sandbox is now created beside the checkout, same drive on every runner, no platform branch.

## Notes

- Behaviour change in principle, invisible in practice. It reaches users only once a tag is cut; anyone pinned to an existing `rev` is unaffected until they bump.
- #71 described the hook as `require_serial: true`; that sentence was removed there, so the two PRs are consistent in either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)