### PR TITLE
Stamp the release's own rev into the published README

### DIFF
--- a/.github/scripts/stamp-readme-rev.sh
+++ b/.github/scripts/stamp-readme-rev.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Rewrite the pre-commit `rev:` in README.md to the release being built, and
+# pin the package version to that same tag.
+#
+# README.md is the PyPI long_description, so the `rev:` in it is what users
+# copy off the project page. sync_readme_to_release.yml rewrites that line only
+# *after* a release is published, which is too late for the artifacts built
+# from the tag: v4.0.0 shipped `rev: v3.13.0.3`, and v3.13.0.3 shipped
+# `rev: v3.13.0.1`. Rewriting it here, in the build tree only, makes each
+# artifact advertise itself.
+#
+# Pinning the version is not optional. The rewrite leaves the working tree
+# dirty, and setuptools-scm treats a dirty tree as "past the tag": building
+# v4.0.0 dirty yields 4.0.1.dev0 instead of 4.0.0. SETUPTOOLS_SCM_PRETEND_VERSION
+# keeps the published version exactly the tag. Verified both ways locally.
+#
+# Expects $TAG (e.g. v4.1.0) and, when running under Actions, $GITHUB_ENV.
+set -euo pipefail
+
+: "${TAG:?TAG must be set to the release tag, e.g. v4.1.0}"
+
+python - <<'PY'
+import os
+import pathlib
+import re
+
+tag = os.environ["TAG"]
+readme = pathlib.Path("README.md")
+text = readme.read_text(encoding="utf-8")
+
+# Same shape as the sed in sync_readme_to_release.yml, so the two agree on
+# what a rev line looks like.
+new_text, count = re.subn(
+    r"(rev:\s+)v?[0-9]+(?:\.[0-9]+)+",
+    lambda m: m.group(1) + tag,
+    text,
+)
+if not count:
+    raise SystemExit("::error::no pre-commit `rev:` line found in README.md")
+
+readme.write_text(new_text, encoding="utf-8")
+print(f"stamped {count} rev line(s) to {tag}")
+PY
+
+# Strip a leading "v": tags are v4.1.0, PEP 440 versions are 4.1.0.
+version="${TAG#v}"
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "SETUPTOOLS_SCM_PRETEND_VERSION=${version}" >>"$GITHUB_ENV"
+  echo "pinned SETUPTOOLS_SCM_PRETEND_VERSION=${version}"
+fi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,6 +40,18 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.x"
+      - name: Point the README's pre-commit rev at this release
+        # README.md is the PyPI long_description and carries the `rev:` users
+        # copy. sync_readme_to_release.yml only rewrites it *after* the release
+        # is published, so the tag these artifacts are built from still names
+        # the previous release: 4.0.0 shipped `rev: v3.13.0.3` and 3.13.0.3
+        # shipped `rev: v3.13.0.1`. Rewrite it in the build tree, never
+        # committed, so each artifact advertises itself.
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: .github/scripts/stamp-readme-rev.sh
       - run: python -m pip install build
       - name: Build wheel
         env:
@@ -65,6 +77,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.x"
+      - name: Point the README's pre-commit rev at this release
+        # Same reasoning as in build-wheels above.
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: .github/scripts/stamp-readme-rev.sh
       - run: python -m pip install build
       - run: python -m build --sdist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -171,6 +190,32 @@ jobs:
         run: |
           python -m pip install twine
           twine check dist/*
+      - name: Check every artifact carries the release version
+        # setuptools-scm derives the version from git state, so a dirty or
+        # detached tree silently yields something like 4.0.1.dev0 instead of
+        # 4.0.0 — and that is what would get published. Assert the filenames
+        # against the tag rather than trusting the derivation.
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          expected="${TAG#v}"
+          shopt -s nullglob
+          artifacts=(dist/*)
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "::error::no artifacts to check"
+            exit 1
+          fi
+          for f in "${artifacts[@]}"; do
+            name="$(basename "$f")"
+            case "$name" in
+              "shfmt_py-$expected-"*.whl | "shfmt_py-$expected.tar.gz")
+                echo "ok: $name" ;;
+              *)
+                echo "::error::$name does not carry version $expected"
+                exit 1 ;;
+            esac
+          done
       - name: Install from the sdist and run it
         # Naming the tarball explicitly makes pip build it from source, which
         # is the path a user without a matching wheel would hit.


### PR DESCRIPTION
## The bug

Every artifact this project has ever published advertises the **previous** release in its pre-commit snippet:

```console
$ git show v4.0.0:README.md    | grep rev:   ->   rev: v3.13.0.3
$ git show v3.13.0.3:README.md | grep rev:   ->   rev: v3.13.0.1
$ git show v3.13.0.2:README.md | grep rev:   ->   rev: v3.13.0.1
```

`README.md` is the PyPI `long_description`, so **this is live right now** — pypi.org/project/shfmt-py serves 4.0.0 with `rev: v3.13.0.3`:

```console
$ curl -s https://pypi.org/pypi/shfmt-py/json | jq -r '.info.description' | grep -o 'rev: v[0-9.]*'
rev: v3.13.0.3
```

Copy the snippet off the project page and you silently pin a pre-semver release with an older shfmt. Nothing errors.

**Cause is ordering, not the sed.** `sync_readme_to_release.yml` fires on `release: published` — after the tag the artifacts are built from — so it can only ever fix master for next time.

## The fix, and the trap inside it

Stamp the rev into the build tree before `python -m build`, in `build-wheels` and `build-sdist`. Never committed, so master still gets its sync PR exactly as before.

**Pinning the version alongside it is not optional**, and this is the part worth reviewing. The rewrite leaves the working tree dirty, and setuptools-scm reads a dirty tree as "past the tag". Measured all three cases at `v4.0.0`:

| tree state | built version |
| --- | --- |
| clean | `shfmt_py-4.0.0.tar.gz` |
| dirty (README stamped) | **`shfmt_py-4.0.1.dev0.tar.gz`** |
| dirty + `SETUPTOOLS_SCM_PRETEND_VERSION=4.0.0` | `shfmt_py-4.0.0.tar.gz` |

So the naive version of this fix would have published `4.0.1.dev0` as the 4.0.0 release. The script exports `SETUPTOOLS_SCM_PRETEND_VERSION` from the tag to prevent that.

## Verified end to end

Ran the script against a real `v4.0.0` checkout with `TAG=v4.1.0`, then built:

```
stamped 1 rev line(s) to v4.1.0
pinned SETUPTOOLS_SCM_PRETEND_VERSION=4.1.0
```
```
PKG-INFO Version: 4.1.0
rev in long_description: ['rev: v4.1.0']
```

That `PKG-INFO` is what becomes the PyPI page.

## Both guards fail loudly

- The script exits 1 with `::error::no pre-commit rev: line found in README.md` if the README ever stops carrying one — verified against a README with no rev line. Unlike the auto-opened sync PR, this path runs on real CI.
- `smoke-test-sdist` now asserts every artifact filename carries the release version. That is the check that would have caught the `4.0.1.dev0` case, and it guards the existing derivation too, not just this change.

Logic lives in `.github/scripts/stamp-readme-rev.sh` rather than inline so it can be run outside CI — which is how the numbers above were produced.

## Note

The stamping steps are `if: github.event_name == 'release'`, so PR and push builds are untouched and this PR's own CI exercises the unchanged path. The first real proof comes at the next release; the version assertion is the safety net if anything is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)