### PR TITLE
Publish to PyPI via Trusted Publishing instead of an API token

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -184,8 +184,16 @@ jobs:
     # still runs on every PR / push to catch wheel-build regressions early.
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    # Scopes the OIDC credential: only this environment can mint a token PyPI
+    # will accept, so protection rules on it gate publishing.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/shfmt-py
     permissions:
       contents: read
+      # Lets the job mint the short-lived OIDC token Trusted Publishing
+      # exchanges for an upload token. Nothing else in this workflow needs it.
+      id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -193,7 +201,8 @@ jobs:
           merge-multiple: true
       - name: List artifacts to publish
         run: ls -la dist/
+      # No credentials: the action exchanges this job's OIDC identity for a
+      # short-lived, project-scoped upload token. That also makes it emit PEP
+      # 740 attestations, which it cannot do with an API token because there
+      # is no identity to sign with.
       - uses: pypa/gh-action-pypi-publish@e9ccbe5a211ba3e8363f472cae362b56b104e796
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft on purpose — do not merge until the PyPI side is configured.** The publisher must exist on pypi.org first, and its workflow filename and environment name must match this file exactly, or the first release after merging fails to upload.

## Why

Everything else in this supply chain is pinned — actions by digest, the shfmt binary by sha256, aqua by checksum. The exception is the credential that actually uploads:

```yaml
      - uses: pypa/gh-action-pypi-publish@e9ccbe5a...
        with:
          user: __token__
          password: ${{ secrets.PYPI_API_TOKEN }}
```

A static, non-expiring token in repository secrets, on a package whose entire job is putting an executable on users' `PATH`. A leak there is a malicious release, and nothing expires on its own. `id-token` appears nowhere in `.github/` today, so there is no OIDC anywhere.

Trusted Publishing **removes** the credential rather than protecting it: the job mints a short-lived OIDC token, PyPI exchanges it for an upload token scoped to this project, and nothing long-lived exists to leak.

## Attestations come free

PyPI reports `provenance: None` for all six 4.0.0 files. Under Trusted Publishing the action emits [PEP 740](https://peps.python.org/pep-0740/) attestations **by default** — signing needs an identity an API token cannot provide. That yields a verifiable artifact → repo/workflow/commit link, visible in PyPI's "Verified details" panel and checkable with `gh attestation verify`.

The pinned SHA already supports this: `e9ccbe5a...` is dated 2025-05-23 with commit message *"Merge pull request #359 … bump-pypi-attestations"*, well past v1.11.0 where attestations landed. No extra step and no `actions/attest-build-provenance` needed — in this job that would attest the wrong run.

Two things I am deliberately **not** claiming: `pip install --require-attestations` does not exist, so this is not an end-user enforcement mechanism today; and the attestation says nothing about the embedded Go binary, which is covered separately by the sha256 pins in `setup.py`.

## Setup steps for you (in this order)

1. On pypi.org → shfmt-py → *Publishing*, add a GitHub publisher:
   - Owner `MaxWinterstein`, repository `shfmt-py`
   - **Workflow name:** `python-publish.yml`
   - **Environment name:** `pypi`
2. In repo *Settings → Environments*, the `pypi` environment is created on first use; optionally add protection rules (e.g. required reviewer) — that is the payoff of the `environment:` block.
3. Merge this.
4. Cut a release and confirm the upload succeeds and the PyPI page shows verified provenance.
5. **Then** delete the `PYPI_API_TOKEN` secret and revoke it on PyPI.

Step 5 matters: keeping a revoked-in-spirit-but-live token around gives back exactly the exposure this removes.

## Diff summary

- `permissions:` gains `id-token: write` (the whole point); `contents: read` unchanged.
- New `environment: {name: pypi, url: …}` so protection rules can gate publishing.
- The `with:` block is deleted — no `user`, no `password`.

Nothing else in the workflow changes, and `if: github.event_name == 'release'` still guards the job, so this PR's own CI does not exercise the publish path. That is also why the first real proof is the next release — plan it as a deliberate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)