### PR TITLE
Pin every action by digest, not just the ones with nothing to steal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
         python: ['3.9', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python }}
       - run: pip install ".[test]"
@@ -44,8 +44,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.x'
       - run: python -m pip install pre-commit

--- a/.github/workflows/sync_readme_to_release.yml
+++ b/.github/workflows/sync_readme_to_release.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: master
 
@@ -23,7 +23,7 @@ jobs:
           sed -i -E "s|(rev:[[:space:]]+)v?[0-9]+(\.[0-9]+)+|\\1${TAG}|" README.md
           git --no-pager diff -- README.md
 
-      - uses: peter-evans/create-pull-request@v8
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           # Uses the default GITHUB_TOKEN (job permissions above grant
           # contents:write and pull-requests:write). The auto-opened PR

--- a/.github/workflows/update_aqua_checksums.yml
+++ b/.github/workflows/update_aqua_checksums.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           token: ${{ secrets.PAT }}
           ref: ${{ github.head_ref }}
@@ -49,7 +49,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Install aqua
-        uses: aquaproj/aqua-installer@v4.0.5
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e  # v4.0.5
         with:
           aqua_version: ${{ steps.aqua.outputs.version }}
           # No aqua.yaml at the repo root; this job only regenerates hashes.
@@ -74,5 +74,5 @@ jobs:
           sha="$(curl -sSfL "https://raw.githubusercontent.com/aquaproj/aqua-installer/${version}/aqua-installer" | sha256sum | cut -d' ' -f1)"
           sed -i "s|^ARG AQUA_INSTALLER_SHA256=.*|ARG AQUA_INSTALLER_SHA256=${sha}|" Dockerfile
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d  # v7.2.0
         if: ${{ env.commit_message != 'Apply automatic changes' }}

--- a/.github/workflows/update_shfmt_checksums.yml
+++ b/.github/workflows/update_shfmt_checksums.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           token: ${{ secrets.PAT }}
           # Need history so the script can read setup.py at HEAD~1 to
@@ -32,7 +32,7 @@ jobs:
         run: echo "commit_message=$(git log -1 --pretty=%s)" >> "$GITHUB_ENV"
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.x'
 
@@ -44,5 +44,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/workflows/update_shfmt_checksums.py
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d  # v7.2.0
         if: ${{ env.commit_message != 'Apply automatic changes' }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     "github>aquaproj/aqua-renovate-config:file#2.13.0(\\.vibepod/overlay/aqua\\.yaml)"
   ],
   "customManagers": [


### PR DESCRIPTION
## The pinning was backwards

`python-publish.yml` digest-pins all five of its actions — and those jobs run with `permissions: contents: read` and nothing worth stealing.

Meanwhile the workflows that *do* hold credentials used mutable tags:

| workflow | credential | actions on mutable tags |
| --- | --- | --- |
| `update_shfmt_checksums.yml` | `token: ${{ secrets.PAT }}` | `git-auto-commit-action@v7` |
| `update_aqua_checksums.yml` | `token: ${{ secrets.PAT }}` | `aqua-installer@v4.0.5`, `git-auto-commit-action@v7` |
| `sync_readme_to_release.yml` | `contents: write` + `pull-requests: write` | `create-pull-request@v8` |

`actions/checkout` persists that PAT into `.git/config`, so **every later step in those jobs can read a personal access token**. A tag is a mutable pointer; whoever can move it runs code in a job that has one. Worth noting `v4.0.5` was no safer than `v7` despite looking exact — a patch tag is still mutable.

## What changed

Every action reference is now digest-pinned with the version in a trailing comment, matching the style `python-publish.yml` already used. Each digest was resolved from the API **at the tag the workflow currently requests**, so this changes what is *guaranteed*, not what *runs*:

```
actions/checkout@v7                     -> 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
actions/setup-python@v7                 -> 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
stefanzweifel/git-auto-commit-action@v7 -> 4a55954c782fc1ea30b9056cd3e7a2b40ca8887d  # v7.2.0
aquaproj/aqua-installer@v4.0.5          -> 96a9bc20066c5bf5e275b41019cfc165b25f4e2e  # v4.0.5
peter-evans/create-pull-request@v8      -> 5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
```

(The floating `v7` on `git-auto-commit-action` currently resolves to v7.2.0, not v7.0.0 — worth knowing what you were actually running.)

`main.yml` is included even though it has nothing to steal either. Leaving two styles in one repo is how the interesting ones get missed.

## Renovate

Added `helpers:pinGitHubActionDigests` to `renovate.json`. Pinning without automation just trades a mutable reference for a stale one; this makes Renovate bump the digests and keep the version comments in sync.

## Verification

- Every digest resolved from `gh api repos/<action>/commits/<tag>`.
- `grep -rnE "uses: .*@v[0-9]" .github/workflows/ | grep -v "  # v"` → **no floating tags remain**; 25 references pinned.
- All five workflow files parse as YAML; `renovate.json` parses as JSON.

Deliberately **not** included: `persist-credentials: false`. The publish jobs have nothing to protect, and the PAT checkouts *need* the persisted credential in order to push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)