### PR TITLE
Make the PyPI page findable and navigable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shfmt-py"
-description = "Python wrapper around invoking shfmt (https://github.com/mvdan/sh)"
+# This is the one line PyPI search results and `pip index` show, so it leads
+# with what you get rather than how it is built. Deliberately does not say
+# "wrapper around invoking shfmt" — there is nothing to import or call.
+description = "Installs the shfmt shell script formatter binary, plus a ready-made pre-commit hook"
 readme = "README.md"
 # The authored code is MIT. Every wheel also contains upstream's shfmt
 # binary, which is BSD-3-Clause, so the distribution as a whole is both —
@@ -18,7 +21,13 @@ authors = [
     {name = "Max Winterstein", email = "github@winterstein.io"},
 ]
 requires-python = ">=3.9"
+# What someone actually types into PyPI search when looking for this.
+keywords = ["shfmt", "shell", "bash", "formatter", "pre-commit", "pre-commit-hook"]
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Environment :: Console",
+    "Topic :: Software Development :: Quality Assurance",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     # Every version allowed by requires-python. The distribution ships no
@@ -44,7 +53,13 @@ dynamic = ["version"]
 test = ["pytest>=7", "setuptools>=70.1"]
 
 [project.urls]
-Homepage = "https://github.com/maxwinterstein/shfmt-py"
+# These become the PyPI sidebar. With only Homepage there was no route from
+# the project page to the issue tracker or to what a release actually bundles.
+# No Source row on purpose — it would just repeat Homepage.
+Homepage = "https://github.com/MaxWinterstein/shfmt-py"
+Issues = "https://github.com/MaxWinterstein/shfmt-py/issues"
+Changelog = "https://github.com/MaxWinterstein/shfmt-py/releases"
+"Upstream (mvdan/sh)" = "https://github.com/mvdan/sh"
 
 [tool.setuptools_scm]
 # Strip any local version segment so PyPI accepts the version.


### PR DESCRIPTION
Three gaps, all in metadata rather than docs.

## 1. The summary contradicted the README

```toml
description = "Python wrapper around invoking shfmt (https://github.com/mvdan/sh)"
```

The README now says, in its second paragraph: *"no Python API: nothing to `import`, no `python -m shfmt`"*. This line said the opposite — and it is the **only** line PyPI search results and `pip index` show. Replaced with what you actually get, mentioning the pre-commit hook since that's the dominant use:

> Installs the shfmt shell script formatter binary, plus a ready-made pre-commit hook

## 2. The PyPI sidebar was a dead end

`[project.urls]` had one row. Live proof:

```console
$ curl -s https://pypi.org/pypi/shfmt-py/json | jq '.info.project_urls'
{ "Homepage": "https://github.com/maxwinterstein/shfmt-py" }
```

No route from the project page to the issue tracker, or to what a release bundles. Added `Issues`, `Changelog` (→ `/releases`, which is where the shfmt-version answer lives now that the README points at tags) and an upstream `mvdan/sh` row. No `Source` row — it would just repeat Homepage. Also normalised the owner casing to `MaxWinterstein`.

## 3. Nothing to match a search on

Added `keywords` (`shfmt`, `shell`, `bash`, `formatter`, `pre-commit`, `pre-commit-hook`) and the four non-version classifiers that describe *what this is* rather than which interpreters it runs on: Development Status, Intended Audience, Environment :: Console, Topic :: Software Development :: Quality Assurance.

Deliberately no `Operating System ::` classifier — the wheels are platform-specific, so `OS Independent` would be false and enumerating them would duplicate the wheel tags.

## Verified

Local `uv build`, then read the wheel METADATA:

```
Summary: Installs the shfmt shell script formatter binary, plus a ready-made pre-commit hook
Project-URL: Homepage, https://github.com/MaxWinterstein/shfmt-py
Project-URL: Issues, https://github.com/MaxWinterstein/shfmt-py/issues
Project-URL: Changelog, https://github.com/MaxWinterstein/shfmt-py/releases
Project-URL: Upstream (mvdan/sh), https://github.com/mvdan/sh
Keywords: shfmt,shell,bash,formatter,pre-commit,pre-commit-hook
Classifier: Development Status :: 5 - Production/Stable
...
```

`twine check` PASSED on wheel and sdist — that is the check that rejects an unregistered classifier at upload time, so the four new ones are real.

## Related, but not in this PR (GitHub-side settings, no code)

`gh api repos/MaxWinterstein/shfmt-py` currently returns `"topics": []`, `"homepage": ""`, and a description of *"python3/pip3 wrapper for installing shfmt"* — which, like the old summary, contains neither "pre-commit" nor "hook". Those are settings, not files; happy to send the `gh` commands or do it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)