### PR TITLE
Test the checksum guard that decides what lands on users' PATH

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for the setup.py tests.
+
+setup.py is loaded via importlib (rather than `import setup`) so we can give
+the module its own name and avoid colliding with anything else in sys.modules.
+The `if __name__ == "__main__":` guard at the bottom of setup.py keeps the real
+setup() call from running when we do.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+import pytest
+
+SETUP_PY = Path(__file__).parent.parent / "setup.py"
+
+
+def _load_setup_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("setup_under_test", SETUP_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def setup_mod() -> types.ModuleType:
+    """A freshly loaded setup.py, so tests cannot leak state into each other."""
+    return _load_setup_module()

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -10,26 +10,12 @@ See tests/test_fallback.py for why setup.py is loaded via importlib.
 
 from __future__ import annotations
 
-import importlib.util
-import types
 from pathlib import Path
 
 import pytest
 from setuptools.dist import Distribution
 
 SETUP_PY = Path(__file__).parent.parent / "setup.py"
-
-
-def _load_setup_module() -> types.ModuleType:
-    spec = importlib.util.spec_from_file_location("setup_under_test", SETUP_PY)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-@pytest.fixture
-def setup_mod() -> types.ModuleType:
-    return _load_setup_module()
 
 
 @pytest.fixture

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,101 @@
+"""Tests for the integrity check in setup.py's download().
+
+This is the security-critical path of the whole distribution: on every install
+that builds from source, download() is what decides whether the bytes fetched
+from GitHub become the shfmt binary on the user's PATH. CI only ever downloads
+*correct* binaries, so an inverted comparison or a mismatch downgraded to a
+warning would go green everywhere while silently accepting any payload.
+
+No network: urlopen is stubbed, so these assert the logic rather than GitHub.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+PAYLOAD = b"#!/bin/sh\necho not really shfmt\n"
+PAYLOAD_SHA256 = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urlopen returns.
+
+    Implements the context-manager protocol for real, because download() uses
+    `with urllib.request.urlopen(url) as resp:` — a MagicMock would satisfy
+    that by accident and prove nothing.
+    """
+
+    def __init__(self, data: bytes, code: int = 200) -> None:
+        self._data = data
+        self._code = code
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def getcode(self) -> int:
+        return self._code
+
+    def read(self) -> bytes:
+        return self._data
+
+
+@pytest.fixture
+def fake_urlopen(setup_mod, monkeypatch):
+    """Point setup.py's urlopen at a canned response."""
+
+    def _install(data: bytes, code: int = 200):
+        monkeypatch.setattr(
+            setup_mod.urllib.request,
+            "urlopen",
+            lambda url: _FakeResponse(data, code),
+        )
+
+    return _install
+
+
+def test_download_returns_bytes_when_checksum_matches(setup_mod, fake_urlopen):
+    fake_urlopen(PAYLOAD)
+
+    assert setup_mod.download("https://example.invalid/shfmt", PAYLOAD_SHA256) == PAYLOAD
+
+
+def test_download_rejects_a_checksum_mismatch(setup_mod, fake_urlopen):
+    """The one that matters: wrong bytes must abort the install, not warn."""
+    fake_urlopen(b"totally different bytes")
+
+    with pytest.raises(ValueError, match="sha256 mismatch"):
+        setup_mod.download("https://example.invalid/shfmt", PAYLOAD_SHA256)
+
+
+def test_download_mismatch_message_names_both_checksums(setup_mod, fake_urlopen):
+    """A bare 'mismatch' leaves the user with nothing to compare against."""
+    fake_urlopen(b"totally different bytes")
+    actual = hashlib.sha256(b"totally different bytes").hexdigest()
+
+    with pytest.raises(ValueError) as excinfo:
+        setup_mod.download("https://example.invalid/shfmt", PAYLOAD_SHA256)
+
+    assert PAYLOAD_SHA256 in str(excinfo.value)
+    assert actual in str(excinfo.value)
+
+
+def test_download_rejects_a_non_ok_status(setup_mod, fake_urlopen):
+    """An error page hashes to something; it must not be mistaken for a binary."""
+    fake_urlopen(b"<html>404</html>", code=404)
+
+    with pytest.raises(ValueError, match="HTTP failure"):
+        setup_mod.download("https://example.invalid/shfmt", PAYLOAD_SHA256)
+
+
+def test_every_pinned_platform_has_a_64_hex_digit_sha256(setup_mod):
+    """Guards the hand-maintained table the update bot rewrites."""
+    assert setup_mod.POSTFIX_SHA256, "platform table is empty"
+
+    for key, (postfix, sha256) in setup_mod.POSTFIX_SHA256.items():
+        assert len(sha256) == 64, f"{key} -> {postfix}: sha256 is not 64 chars"
+        assert not set(sha256) - set("0123456789abcdef"), f"{key} -> {postfix}: not lowercase hex"

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -8,26 +8,12 @@ real setup() call from running during these tests.
 
 from __future__ import annotations
 
-import importlib.util
 import sys
-import types
 from pathlib import Path
 
 import pytest
 
 SETUP_PY = Path(__file__).parent.parent / "setup.py"
-
-
-def _load_setup_module() -> types.ModuleType:
-    spec = importlib.util.spec_from_file_location("setup_under_test", SETUP_PY)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-@pytest.fixture
-def setup_mod() -> types.ModuleType:
-    return _load_setup_module()
 
 
 def _exe_basename() -> str:


### PR DESCRIPTION
`download()` in `setup.py` is the security-critical path of this whole distribution. On every install that builds from source — which includes **every pre-commit hook install** — it decides whether bytes fetched from GitHub become the `shfmt` binary on the user's `PATH`.

It had no tests:

```console
$ grep -rn "download" tests/
$            # nothing
```

Meanwhile the wheel-tag override, whose worst failure is a mislabelled file, had three.

## Why the gap matters

CI only ever downloads *correct* binaries. So an inverted comparison, or a mismatch downgraded to a warning, stays green on every runner and every platform while silently accepting any payload. There is no scenario in which existing CI notices.

## What's added

Five tests, no network. `urlopen` is stubbed with a response object that implements the context-manager protocol **for real** — `download()` uses `with urllib.request.urlopen(url) as resp:`, and a `MagicMock` would satisfy that by accident and prove nothing.

| test | guards |
| --- | --- |
| matching checksum returns bytes | the happy path still works |
| mismatched checksum **raises** | the actual security property |
| message names both digests | a user hitting it has something to compare |
| non-200 raises | an error page isn't hashed as if it were a binary |
| every `POSTFIX_SHA256` entry is 64 lowercase hex | the hand-maintained table the update bot rewrites |

## The tests can fail

Mutation-tested by replacing the raise with a print:

```diff
-        raise ValueError(f"sha256 mismatch, expected {sha256}, got {checksum}")
+        print(f"WARNING: sha256 mismatch, expected {sha256}, got {checksum}")
```

```
FAILED tests/test_download.py::test_download_rejects_a_checksum_mismatch - Failed: DID NOT RAISE ValueError
FAILED tests/test_download.py::test_download_mismatch_message_names_both_checksums - Failed: DID NOT RAISE ValueError
2 failed, 8 passed
```

Exactly the two integrity tests, nothing else. Unmutated: **10 passed** (was 5).

## Drive-by

`_load_setup_module()` and the `setup_mod` fixture were copy-pasted verbatim in both existing test files; this PR would have made it three. Moved to `tests/conftest.py`, and the duplicates removed — `ruff check` and `ruff format` clean under the repo's own config.

Deliberately **not** testing `save_executable`'s chmod (the matrix already proves the binary runs on every platform) or `get_download_url` (a format string whose output the smoke tests exercise for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)