### PR TITLE
Fail the checksum bot when a substitution misses

### DIFF
--- a/.github/workflows/update_shfmt_checksums.py
+++ b/.github/workflows/update_shfmt_checksums.py
@@ -93,26 +93,34 @@ print("[INFO] Updating setup.py with new checksums...")
 
 new_content = content
 updated = False
+unmatched = []
 
 # Directly update variables in setup.py with the new checksums
 for var_name, sha in checksums.items():
-    print(f"[DEBUG] var_name: {var_name}")
-    # Match either quote style (legacy single-quoted or current double-quoted).
-    pattern = rf"""({var_name}\s*=\s*)["'][a-fA-F0-9]{{64}}["']"""
-    replacement = rf'\1"{sha}"'  # Always emit double quotes (codebase convention).
+    # Anchored at the start of a line so a short name cannot match the tail of
+    # a longer identifier. Matches either quote style (legacy single-quoted or
+    # current double-quoted) and always emits double quotes.
+    pattern = rf"""(^{re.escape(var_name)}\s*=\s*)["'][a-fA-F0-9]{{64}}["']"""
+    new_content, count = re.subn(pattern, rf'\1"{sha}"', new_content, flags=re.MULTILINE)
 
-    # Debug: print the pattern we are searching for
-    print(f"[DEBUG] Searching for pattern: {pattern}")
-
-    if re.search(pattern, new_content):
-        new_content = re.sub(pattern, replacement, new_content)
+    if count:
         print(f"[INFO] Updated checksum for {var_name}: {sha}")
         updated = True
     else:
-        print(f"[WARNING] Could not find pattern for {var_name}. Check your setup.py format.")
+        unmatched.append(var_name)
+
+# Every other failure in this script exits non-zero; this one used to warn and
+# carry on. Because `updated` goes True as soon as any *other* variable matches,
+# a single missed substitution wrote the file, got committed by
+# git-auto-commit-action and exited 0 — shipping a stale hash for that platform
+# with nothing in the run marked red.
+if unmatched:
+    print(f"[ERROR] No assignment found in {SHFMT_VERSION_FILE} for: {sorted(unmatched)}")
+    print("[ERROR] Refusing to write a partial update: those platforms would keep stale hashes.")
+    sys.exit(1)
 
 if not updated:
-    print("[WARNING] No checksums were updated. Maybe they are already correct?")
+    print("[INFO] No checksums needed updating; they already match.")
 else:
     with open(SHFMT_VERSION_FILE, "w") as f:
         f.write(new_content)


### PR DESCRIPTION
`update_shfmt_checksums.py` exits non-zero when it cannot read `setup.py`, cannot reach the API, extracts nothing, or is missing a platform. Then the rewrite loop hit a variable it could not find and merely warned:

```python
    else:
        print(f"[WARNING] Could not find pattern for {var_name}. Check your setup.py format.")
```

`updated` had already gone `True` from the other six variables, so the file was written anyway, `git-auto-commit-action` committed it, and the run exited 0. **One platform keeps a stale hash for the previous shfmt release, with nothing red anywhere.**

## Reproduced against the real API

Renamed `darwin_arm64` in `setup.py`, then ran both versions:

**Before**
```
[WARNING] Could not find pattern for darwin_arm64. Check your setup.py format.
[SUCCESS] setup.py updated with new checksums!
exit=0        <- and the file was written
```

**After**
```
[ERROR] No assignment found in setup.py for: ['darwin_arm64']
[ERROR] Refusing to write a partial update: those platforms would keep stale hashes.
exit=1        <- file untouched
```

Unmodified input still updates all seven and exits 0 (verified as a control run).

## Also in here

- **Anchored the pattern** with `^` + `re.MULTILINE` and `re.escape`d the variable name, so a short name cannot match the tail of a longer identifier. `re.subn` replaces the separate `re.search` + `re.sub`, which walked the content twice.
- **Dropped the per-iteration DEBUG prints** of the variable name and the regex — they said nothing the INFO and ERROR lines don't, and the regex dump made real failures harder to spot.
- **Demoted** the "no checksums were updated" case from WARNING to INFO. That one is a genuine no-op: the bot runs after a Renovate bump, so hashes already being correct is the normal path, not a problem.

## How likely was this?

Latent, not live — it needs someone touching those assignments in the same window as an upstream bump. But it is three lines, and it was the one fail-quiet spot in an otherwise fail-loud pipeline that guards what gets executed on users' machines.

`ruff check` and `ruff format --check` clean under the repo's config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)