### PR TITLE
Let Renovate keep rebasing its own checksum PRs

### DIFF
--- a/.github/workflows/update_aqua_checksums.yml
+++ b/.github/workflows/update_aqua_checksums.yml
@@ -76,3 +76,12 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d  # v7.2.0
         if: ${{ env.commit_message != 'Apply automatic changes' }}
+        with:
+          # Renovate reads the author *and* the committer of every commit on
+          # its branch, and stops rebasing the PR as soon as it sees an email
+          # it doesn't know. The action would otherwise take the author from
+          # github.actor and the committer from its own default, so pin both
+          # to the one identity listed in renovate.json's gitIgnoredAuthors.
+          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/update_shfmt_checksums.yml
+++ b/.github/workflows/update_shfmt_checksums.yml
@@ -46,3 +46,12 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d  # v7.2.0
         if: ${{ env.commit_message != 'Apply automatic changes' }}
+        with:
+          # Renovate reads the author *and* the committer of every commit on
+          # its branch, and stops rebasing the PR as soon as it sees an email
+          # it doesn't know. The action would otherwise take the author from
+          # github.actor and the committer from its own default, so pin both
+          # to the one identity listed in renovate.json's gitIgnoredAuthors.
+          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
     "helpers:pinGitHubActionDigests",
     "github>aquaproj/aqua-renovate-config:file#2.13.0(\\.vibepod/overlay/aqua\\.yaml)"
   ],
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Fixes the ["Edited/Blocked Notification"](https://github.com/MaxWinterstein/shfmt-py/pull/67#issuecomment-5461975273) Renovate posts on its own PRs once a checksum job has run.

### What happens today

Renovate's `isBranchModified` walks every commit on its branch and collects **both** the author and the committer email ([`lib/util/git/index.ts`](https://github.com/renovatebot/renovate/blob/main/lib/util/git/index.ts)):

```ts
for (const commit of commits.all) {
  committedAuthors.add(commit.author_email);
  committedAuthors.add(commit.committer_email);
}
```

Anything that is not `gitAuthorEmail`, not in `gitIgnoredAuthors`, and not in the platform's own ignore list marks the branch as hand-edited. On GitHub that platform list is just `noreply@github.com`.

Our checksum commit on #67:

```
author    renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>   ok
committer github-actions[bot] <41898282+github-actions[bot]@...>            unrecognized
```

`git-auto-commit-action` derives the author from `github.actor` — which happens to be `renovate[bot]` — but always commits as `github-actions[bot]`. That committer is what trips the check, so Renovate stops rebasing the PR.

### The fix

- Pin both author and committer of the checksum commit to `github-actions[bot]`, in both checksum workflows. The author was previously whoever triggered the run, which is only `renovate[bot]` by coincidence.
- List that one email in `gitIgnoredAuthors`, so Renovate treats the branch as unmodified.

Renovate is then free to rebase over our commit — that's fine, because the same job regenerates the checksums on the next push.

### Verification

- `renovate-config-validator` accepts the config (validated as repository config).
- Both workflows parse, and the `commit_author` value survives YAML as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`.
- Traced `gitIgnoredAuthors` through Renovate's source: repo config → `setUserRepoConfig` → `config.ignoredAuthors` → `isBranchModified`.

### Note on #67

#67 itself is green and safe to merge as-is. Renovate caches the "modified" verdict against the branch SHA, so this config change won't retroactively clear the notice there — ticking the rebase box (or just merging) resolves it. Future Renovate PRs won't hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
