### PR TITLE
Split the attribution out of LICENSE so GitHub detects MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,9 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-Copyright for portions of project shfmt-py are held by Ryan Rhee, 2019,
-as part of the project located at https://github.com/shellcheck-py/shellcheck-py.
-All other copyright for this project are held by Max Winterstein, 2021.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,3 @@
+Copyright for portions of project shfmt-py are held by Ryan Rhee, 2019,
+as part of the project located at https://github.com/shellcheck-py/shellcheck-py.
+All other copyright for this project are held by Max Winterstein, 2021.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ readme = "README.md"
 license = "MIT AND BSD-3-Clause"
 # LICENSE-shfmt is upstream's BSD-3-Clause text. We redistribute the shfmt
 # binary unmodified, and clause 2 requires that notice to travel with binary
-# distributions — which every wheel here is.
-license-files = ["LICENSE", "LICENSE-shfmt"]
+# distributions — which every wheel here is. NOTICE holds the shellcheck-py
+# attribution that used to sit under a rule at the bottom of LICENSE; it was
+# split out so GitHub detects LICENSE as plain MIT instead of "Other".
+license-files = ["LICENSE", "LICENSE-shfmt", "NOTICE"]
 authors = [
     {name = "Max Winterstein", email = "github@winterstein.io"},
 ]


### PR DESCRIPTION
The About sidebar shows the license as **Other** (`spdx_id: NOASSERTION`) while the README and the PyPI badge both say MIT. The repo contradicts itself on the one project where license clarity is more or less the product.

### Cause

`LICENSE` is the verbatim MIT text, then a `---` rule, then a three-line attribution block. Those extra ~40 words push the file below [licensee](https://github.com/licensee/licensee)'s 98% similarity threshold, so GitHub cannot match it to a known license. Multiple leading `Copyright` lines are fine — licensee strips those.

### Change

- `LICENSE` trimmed to end at `...OTHER DEALINGS IN THE SOFTWARE.`
- the attribution moves verbatim to a new `NOTICE`
- `NOTICE` added to `license-files` so it keeps shipping

### Verification

Trimmed `LICENSE` against the canonical choosealicense MIT template, normalised the way licensee does (strip copyright lines, collapse whitespace): **100.00% similarity**.

Local `uv build --wheel`:

```
shfmt_py-*.dist-info/licenses/LICENSE
shfmt_py-*.dist-info/licenses/LICENSE-shfmt
shfmt_py-*.dist-info/licenses/NOTICE

License-Expression: MIT AND BSD-3-Clause
License-File: LICENSE
License-File: LICENSE-shfmt
License-File: NOTICE
```

The shellcheck-py attribution still travels with every distribution, so nothing is lost — it just lives in its own file now. `LICENSE-shfmt` and the `MIT AND BSD-3-Clause` expression are untouched.

Detection only re-runs on the default branch, so after merge:

```
gh api repos/MaxWinterstein/shfmt-py/license --jq '.license.spdx_id'   # expect MIT
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)